### PR TITLE
feat(docs): updated documentation for better clarity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           echo "Publishing version: $VERSION"
           npm --prefix packages/core       version "$VERSION" --no-git-tag-version --allow-same-version
           npm --prefix packages/playwright version "$VERSION" --no-git-tag-version --allow-same-version
+          npm --prefix packages/appium     version "$VERSION" --no-git-tag-version --allow-same-version
           npm --prefix packages/cli        version "$VERSION" --no-git-tag-version --allow-same-version
           npm --prefix packages/zosma-qa   version "$VERSION" --no-git-tag-version --allow-same-version
 
@@ -52,6 +53,12 @@ jobs:
       - name: Publish @zosmaai/zosma-qa-playwright
         run: pnpm publish --access public --no-git-checks
         working-directory: packages/playwright
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @zosmaai/zosma-qa-appium
+        run: pnpm publish --access public --no-git-checks
+        working-directory: packages/appium
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -1,57 +1,62 @@
 # zosma-qa
 
-**Zero-config QA platform — Playwright, AI agents, and extensible test runners.**
+**The open-source QA platform — Web, Mobile, Backend, and Load testing. Zero config. AI-native.**
 
 Drop your tests in. Everything works.
 
 [![CI](https://github.com/zosmaai/zosma-qa/actions/workflows/ci.yml/badge.svg)](https://github.com/zosmaai/zosma-qa/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![npm: zosma-qa](https://img.shields.io/npm/v/zosma-qa?label=zosma-qa)](https://www.npmjs.com/package/zosma-qa)
 
 ---
 
 ## What is zosma-qa?
 
-zosma-qa is an open-source QA framework that gives you a production-ready test infrastructure in minutes. It ships with:
+zosma-qa is a unified QA framework that gives you production-ready test infrastructure in minutes — across your entire stack. One CLI, one config, every test type.
 
-- **TypeScript and Python support** — pick your language at init time
-- **Best-practice Playwright config** — retries, traces, screenshots, video, and HTML reports all configured for you
-- **First-class AI agent support** — Playwright's planner, generator, and healer agents work out of the box
-- **Interactive CLI** (`npx zosma-qa`) — init, run, agent setup, and report commands with friendly prompts
-- **Zero boilerplate** — run `npx zosma-qa init`, answer a few questions, start writing tests
-- **Extensible plugin architecture** — built for future runners: k6, Artillery, REST, accessibility
+| Test Type | Runner | Status |
+|---|---|---|
+| **Web (E2E & Component)** | Playwright | Available |
+| **Mobile (iOS & Android)** | Appium + WebdriverIO | Available |
+| **Load & Performance** | k6 / Artillery | Planned |
+| **REST API** | Supertest / Pactum | Planned |
+| **Accessibility** | axe-core + Playwright | Planned |
+| **Visual Regression** | Percy / Chromatic | Planned |
+
+### Why zosma-qa?
+
+- **Zero boilerplate** — `npx zosma-qa init`, answer a few questions, start testing
+- **TypeScript and Python** — pick your language at init time
+- **First-class AI agent support** — planner, generator, and healer agents work out of the box
+- **Extensible plugin architecture** — every runner implements a shared `ZosmaPlugin` interface
+- **One command** — `npx zosma-qa run` dispatches to the right runner automatically
+
+---
+
+## Packages
+
+| Package | npm | Description |
+|---|---|---|
+| [`zosma-qa`](packages/zosma-qa/) | [![npm](https://img.shields.io/npm/v/zosma-qa)](https://www.npmjs.com/package/zosma-qa) | CLI entry point (`npx zosma-qa`) |
+| [`@zosmaai/zosma-qa-core`](packages/core/) | [![npm](https://img.shields.io/npm/v/@zosmaai/zosma-qa-core)](https://www.npmjs.com/package/@zosmaai/zosma-qa-core) | Shared types, config loader, plugin interface |
+| [`@zosmaai/zosma-qa-playwright`](packages/playwright/) | [![npm](https://img.shields.io/npm/v/@zosmaai/zosma-qa-playwright)](https://www.npmjs.com/package/@zosmaai/zosma-qa-playwright) | Playwright runner and base config |
+| [`@zosmaai/zosma-qa-cli`](packages/cli/) | [![npm](https://img.shields.io/npm/v/@zosmaai/zosma-qa-cli)](https://www.npmjs.com/package/@zosmaai/zosma-qa-cli) | Interactive CLI with prompts |
+| [`@zosmaai/zosma-qa-appium`](packages/appium/) | *Publishing with next release* | Appium mobile testing runner |
 
 ---
 
 ## Quick Start
 
-```bash
-npx zosma-qa init
-```
-
-The CLI will ask you:
-
-1. **Project name** — blank to scaffold in the current directory
-2. **Language** — TypeScript or Python
-3. **Base URL** — the URL of the app you want to test
-4. **Browsers** — chromium (default), firefox, webkit
-5. **AI agents** — TypeScript only; choose OpenCode, Claude Code, VS Code, or skip
-
----
-
-## TypeScript (Playwright)
+### Web Testing (Playwright)
 
 ```bash
 npx zosma-qa init
-# Choose: TypeScript
-
-# Run your tests
+# Choose: TypeScript → enter your base URL → pick browsers → set up AI agents
 npx zosma-qa run
-
-# Open the HTML report
 npx zosma-qa report
 ```
 
-**Use as a base config in your own project:**
+**Or install as a dependency in an existing project:**
 
 ```bash
 npm install -D @zosmaai/zosma-qa-playwright @playwright/test
@@ -67,50 +72,76 @@ export default defineConfig({
 });
 ```
 
+See the full guide: [Getting Started with Playwright](docs/GETTING_STARTED_PLAYWRIGHT.md)
+
 ---
 
-## Python (pytest-playwright)
+### Mobile Testing (Appium)
+
+Test iOS and Android apps with a Playwright-like API:
+
+```bash
+npm install -D @zosmaai/zosma-qa-appium
+```
+
+```typescript
+// tests/login.appium.ts
+import { test } from '@zosmaai/zosma-qa-appium';
+import { tapButton, fillInput, expectText } from '@zosmaai/zosma-qa-appium';
+
+test.describe('Login Flow', () => {
+  test('should login with valid credentials', async ({ driver }) => {
+    await fillInput(driver, 'user@example.com', { testID: 'email-input' });
+    await fillInput(driver, 'password123', { testID: 'password-input' });
+    await tapButton(driver, { testID: 'login-button' });
+    await expectText(driver, 'Welcome back');
+  });
+});
+```
+
+```typescript
+// zosma.config.ts
+import { defineConfig } from '@zosmaai/zosma-qa-core';
+
+export default defineConfig({
+  plugins: ['appium'],
+  baseURL: 'localhost',
+  browsers: ['chromium'],
+});
+```
+
+See the full guide: [Getting Started with Appium](docs/GETTING_STARTED_APPIUM.md)
+
+---
+
+### Python (pytest-playwright)
 
 ```bash
 npx zosma-qa init
 # Choose: Python
 ```
 
-**If [uv](https://docs.astral.sh/uv/) is installed**, `pytest-playwright` is installed automatically. If not, the CLI prints clear setup instructions for both uv and venv+pip.
+If [uv](https://docs.astral.sh/uv/) is installed, `pytest-playwright` is installed automatically. Otherwise the CLI prints setup instructions.
 
 ```bash
-# Download browser binaries
 playwright install
-
-# Run your tests
-npx zosma-qa run        # auto-detects uv.lock and uses `uv run pytest`
-# or directly:
-uv run pytest tests/test_seed.py
+npx zosma-qa run        # auto-detects uv.lock → uses `uv run pytest`
 ```
 
-**Scaffolded files:**
+Scaffolded files:
 
 ```
-tests/test_seed.py   ← seed test, uses pytest-playwright's page fixture
-conftest.py          ← shared fixtures placeholder
+tests/test_seed.py   ← seed test with page fixture
+conftest.py          ← shared fixtures
 pyproject.toml       ← pytest config + pytest-playwright dependency
-zosma.config.ts      ← zosma layer config (plugins: ['pytest'])
+zosma.config.ts      ← plugins: ['pytest']
 ```
 
-**`pyproject.toml` (example):**
+---
 
-```toml
-[project]
-name = "my-project"
-version = "0.1.0"
-requires-python = ">=3.9"
-dependencies = ["pytest-playwright>=0.5.0"]
+### Load Testing (k6 / Artillery) — Planned
 
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-base_url = "https://www.myapp.com"
-addopts = "--browser chromium"
-```
+Load testing support via k6 and Artillery is on the roadmap. See [Load Testing](docs/GETTING_STARTED_LOAD_TESTING.md) for status and planned features.
 
 ---
 
@@ -119,7 +150,7 @@ addopts = "--browser chromium"
 | Command | Description |
 |---|---|
 | `npx zosma-qa init` | Interactive scaffold — language, baseURL, browsers, AI agents |
-| `npx zosma-qa run` | Run all tests (auto-detects TypeScript or Python) |
+| `npx zosma-qa run` | Run all tests (auto-detects runner from config) |
 | `npx zosma-qa run --grep "checkout"` | Run tests matching a pattern |
 | `npx zosma-qa run --headed` | Run in headed (visible) browser mode |
 | `npx zosma-qa run --project firefox` | TypeScript only — run a specific browser project |
@@ -130,20 +161,18 @@ addopts = "--browser chromium"
 
 ## AI Agents
 
-zosma-qa is designed for Playwright's built-in AI agents: **planner**, **generator**, and **healer**.
+zosma-qa integrates with Playwright's built-in AI agents: **planner**, **generator**, and **healer**.
 
-> **Note:** AI agent scaffolding (`npx playwright init-agents`) is currently TypeScript-only. Python projects can still use AI tools directly with `tests/test_seed.py` as the entry point.
+> AI agent scaffolding is currently TypeScript-only. Python projects can still use AI tools directly with `tests/test_seed.py` as the entry point.
 
-### Set up (TypeScript)
+### Setup
 
 ```bash
 npx zosma-qa agents init
 # Prompts: OpenCode (default) / Claude Code / VS Code
 ```
 
-### Use
-
-Once set up, prompt your AI tool:
+### Usage
 
 ```
 Use the planner agent. Seed: tests/seed.spec.ts.
@@ -158,57 +187,57 @@ Use the generator agent with specs/checkout.md
 Use the healer agent on tests/checkout/add-to-cart.spec.ts
 ```
 
-The agent definitions live in `.github/agents/` and follow Playwright's conventions:
-
-```
-.github/agents/    ← agent definitions (auto-generated, commit these)
-specs/             ← planner writes .md test plans here
-tests/             ← generator writes test files here
-tests/seed.spec.ts ← TypeScript AI agent entry point
-tests/test_seed.py ← Python AI agent entry point
-```
+Agent definitions are stored in `.github/agents/` following Playwright conventions.
 
 ---
 
-## Example: testing zosma.ai
+## Examples
 
-A complete, working example is in `examples/zosma-ai/`. It covers:
+### Web: testing zosma.ai
+
+A complete Playwright test suite is in [`examples/zosma-ai/`](examples/zosma-ai/):
 
 | Test file | What it tests |
 |---|---|
 | `tests/seed.spec.ts` | Homepage loads, brand visible — AI agent entry point |
 | `tests/home.spec.ts` | Hero, nav, CTA, How It Works, FAQ, footer |
 | `tests/about.spec.ts` | Team cards, Our Story, Our Values |
-| `tests/openzosma.spec.ts` | Product page, GitHub links, tech stack, terminal snippet |
-| `tests/contact.spec.ts` | Full form fill + submit (network mocked — no real data sent) |
+| `tests/openzosma.spec.ts` | Product page, GitHub links, tech stack |
+| `tests/contact.spec.ts` | Full form fill + submit (network mocked) |
 
 ```bash
-# Run the example suite
 pnpm test:examples
 ```
+
+### Mobile: Appium demo
+
+A sample Appium test project is in [`examples/appium-demo/`](examples/appium-demo/). It demonstrates test structure, fixtures, and agent-friendly helpers for React Native apps.
+
+```bash
+cd examples/appium-demo
+cat tests/login.appium.ts
+```
+
+See the [example README](examples/appium-demo/README.md) for prerequisites and setup.
 
 ---
 
 ## Configuration
 
-### TypeScript projects
-
-**`playwright.config.ts`** — Playwright-specific settings:
+### TypeScript projects (Playwright)
 
 ```typescript
+// playwright.config.ts
 import { defineConfig } from '@zosmaai/zosma-qa-playwright';
 
 export default defineConfig({
-  use: {
-    baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
-  },
+  use: { baseURL: process.env.BASE_URL ?? 'http://localhost:3000' },
   browsers: ['chromium', 'firefox', 'webkit'],
 });
 ```
 
-**`zosma.config.ts`** — Top-level runner settings:
-
 ```typescript
+// zosma.config.ts
 import { defineConfig } from '@zosmaai/zosma-qa-core';
 
 export default defineConfig({
@@ -219,28 +248,27 @@ export default defineConfig({
 });
 ```
 
+### Mobile projects (Appium)
+
+```typescript
+// zosma.config.ts
+import { defineConfig } from '@zosmaai/zosma-qa-core';
+
+export default defineConfig({
+  plugins: ['appium'],
+  baseURL: 'localhost',
+  browsers: ['chromium'],
+});
+```
+
 ### Python projects
 
-**`pyproject.toml`** — pytest-playwright native config:
-
 ```toml
+# pyproject.toml
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 base_url = "http://localhost:3000"
 addopts = "--browser chromium"
-```
-
-**`zosma.config.ts`** — Top-level runner settings (same shape, different plugin):
-
-```typescript
-import { defineConfig } from '@zosmaai/zosma-qa-core';
-
-export default defineConfig({
-  plugins: ['pytest'],
-  testDir: './tests',
-  baseURL: 'http://localhost:3000',
-  browsers: ['chromium'],
-});
 ```
 
 ---
@@ -250,16 +278,22 @@ export default defineConfig({
 ```
 zosma-qa/
 ├── packages/
-│   ├── core/          @zosmaai/zosma-qa-core      — types, config loader, plugin interface
-│   ├── playwright/    @zosmaai/zosma-qa-playwright — base config, runner plugin
-│   └── cli/           @zosmaai/zosma-qa-cli        — `npx zosma-qa` CLI
+│   ├── core/          @zosmaai/zosma-qa-core        — types, config, plugin interface
+│   ├── playwright/    @zosmaai/zosma-qa-playwright   — Playwright runner + base config
+│   ├── appium/        @zosmaai/zosma-qa-appium       — Appium mobile runner + test helpers
+│   ├── cli/           @zosmaai/zosma-qa-cli          — interactive CLI
+│   └── zosma-qa/      zosma-qa                       — CLI entry point wrapper
 ├── templates/
-│   ├── playwright/                — reference scaffold for TypeScript projects
-│   └── playwright-python/        — reference scaffold for Python projects
-├── examples/zosma-ai/             — working tests against zosma.ai
+│   ├── playwright/                — TypeScript scaffold
+│   └── playwright-python/        — Python scaffold
+├── examples/
+│   ├── zosma-ai/                  — Playwright tests against zosma.ai
+│   └── appium-demo/               — Appium mobile test examples
 ├── tests/                         — your tests go here
-├── specs/                         — AI planner output goes here
-├── .github/agents/                — Playwright agent definitions
+├── specs/                         — AI planner output
+├── .github/
+│   ├── agents/                    — Playwright agent definitions
+│   └── workflows/                 — CI/CD (ci.yml, release.yml)
 └── docs/
 ```
 
@@ -267,9 +301,17 @@ zosma-qa/
 
 ## Docs
 
+### Getting Started Guides
+
+- [Getting Started with Playwright](docs/GETTING_STARTED_PLAYWRIGHT.md) — web & component testing
+- [Getting Started with Appium](docs/GETTING_STARTED_APPIUM.md) — iOS & Android mobile testing
+- [Getting Started with Load Testing](docs/GETTING_STARTED_LOAD_TESTING.md) — k6 & Artillery (planned)
+
+### Reference
+
 - [Architecture](docs/ARCHITECTURE.md)
-- [Getting Started](docs/GETTING_STARTED.md)
-- [Vision](docs/VISION.md)
+- [Getting Started (General)](docs/GETTING_STARTED.md)
+- [Vision & Roadmap](docs/VISION.md)
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,14 +2,16 @@
 
 ## Overview
 
-zosma-qa is structured as a **pnpm monorepo** with three publishable packages and a clear separation between the framework core, the Playwright runner, and the CLI UX layer.
+zosma-qa is structured as a **pnpm monorepo** with five publishable packages and a clear separation between the framework core, test runners, and the CLI UX layer.
 
 ```
 zosma-qa/
 ├── packages/
 │   ├── core/          — plugin interface, config system, test discovery
-│   ├── playwright/    — Playwright runner and base config
-│   └── cli/           — interactive CLI (`npx zosma-qa`)
+│   ├── playwright/    — Playwright runner and base config (web testing)
+│   ├── appium/        — Appium runner, test helpers, device management (mobile testing)
+│   ├── cli/           — interactive CLI (`npx zosma-qa`)
+│   └── zosma-qa/      — CLI entry point wrapper
 ├── templates/         — scaffold content for `npx zosma-qa init`
 ├── examples/          — working test suites that demo the framework
 ├── tests/             — root test directory (users put their tests here)
@@ -26,9 +28,17 @@ zosma-qa/
   ├── @zosmaai/zosma-qa-core
   └── @zosmaai/zosma-qa-playwright
         └── @zosmaai/zosma-qa-core
+
+@zosmaai/zosma-qa-appium
+  └── @zosmaai/zosma-qa-core
+  (peer: appium >=2.0.0)
+
+zosma-qa (entry point wrapper)
+  └── @zosmaai/zosma-qa-cli
 ```
 
-`@playwright/test` is a **peer dependency** of `@zosmaai/zosma-qa-playwright` — users supply their own version, ensuring they can upgrade Playwright independently.
+- `@playwright/test` is a **peer dependency** of `@zosmaai/zosma-qa-playwright` — users supply their own version
+- `appium` is a **peer dependency** of `@zosmaai/zosma-qa-appium` — users install it globally or locally
 
 ---
 
@@ -89,6 +99,32 @@ video: retain-on-failure
 
 ---
 
+## packages/appium
+
+**Purpose:** Appium runner plugin for mobile testing (iOS, Android, React Native, Flutter).
+
+**Key modules:**
+
+| Module | Description |
+|---|---|
+| `config/` | Config types, smart defaults, capabilities builder, auto-detection |
+| `server/` | Appium server lifecycle (start, stop, health checks, port allocation) |
+| `device/` | Device management (iOS simulators, Android emulators, React Native detection) |
+| `webdriver/` | WebdriverIO session management, test execution, test loading |
+| `utils/` | Agent-friendly test helpers (`tapButton`, `fillInput`, `expectText`, etc.) |
+| `test-builder.ts` | Playwright-compatible `test()` API with `{ driver }` fixture |
+| `runner.ts` | `AppiumRunner` — orchestrates config, server, session, tests, cleanup |
+| `discovery.ts` | Finds `.appium.ts` and `.appium.py` test files |
+
+**Design decisions:**
+- Tests use a Playwright-like API (`test.describe`, `test.beforeEach`) for consistency
+- The `driver` fixture is a WebdriverIO `Browser` instance injected automatically
+- High-level helpers (`tapButton`, `fillInput`) are designed to be readable by AI agents
+- Smart defaults auto-detect app path, device, and platform from React Native projects
+- `appium` is a peer dependency — users install their own version
+
+---
+
 ## packages/cli
 
 **Purpose:** Developer-facing UX layer. All commands delegate to underlying tools — the CLI adds prompts, colour, and discoverability, not functionality.
@@ -146,11 +182,15 @@ The `init` command scaffolds this structure and optionally runs `playwright init
 - `*.spec.ts`, `*.test.ts`
 - `*.spec.js`, `*.test.js`
 
+`@zosmaai/zosma-qa-appium`'s `findAppiumTests()` discovers mobile test files matching:
+- `*.appium.ts`, `*.appium.js`
+- `*.appium.py`
+
 Ignored directories: `node_modules`, `dist`, `.git`, `.playwright`, `playwright-report`, `test-results`.
 
 ---
 
-## Adding a New Runner Plugin (Future)
+## Adding a New Runner Plugin
 
 1. Create `packages/<runner>/` with a `package.json`
 2. Implement `ZosmaPlugin` from `@zosmaai/zosma-qa-core`
@@ -158,7 +198,7 @@ Ignored directories: `node_modules`, `dist`, `.git`, `.playwright`, `playwright-
 4. Add the runner name to `zosma.config.ts`'s `plugins` array
 5. The CLI's `run` command will pick it up
 
-Example skeleton:
+See `packages/appium/` for a complete reference implementation. Here's a minimal skeleton:
 
 ```typescript
 import type { ZosmaPlugin, RunnerConfig, TestResult } from '@zosmaai/zosma-qa-core';

--- a/docs/GETTING_STARTED_APPIUM.md
+++ b/docs/GETTING_STARTED_APPIUM.md
@@ -1,0 +1,368 @@
+# Getting Started with Appium (Mobile Testing)
+
+This guide covers setting up zosma-qa for mobile app testing on iOS and Android using Appium and WebdriverIO.
+
+---
+
+## Prerequisites
+
+### Required
+
+- **Node.js** >= 18
+- **Appium** >= 2.0
+
+  ```bash
+  npm install -g appium
+  ```
+
+### iOS Testing
+
+- **macOS** (required for iOS simulators)
+- **Xcode** — install from the Mac App Store
+- **Xcode Command Line Tools**:
+
+  ```bash
+  xcode-select --install
+  ```
+
+- **XCUITest driver**:
+
+  ```bash
+  appium driver install xcuitest
+  ```
+
+### Android Testing
+
+- **Android Studio** — [download here](https://developer.android.com/studio)
+- **Android SDK** — installed via Android Studio
+- **`ANDROID_HOME`** environment variable set:
+
+  ```bash
+  export ANDROID_HOME=$HOME/Library/Android/sdk  # macOS
+  export PATH=$PATH:$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools
+  ```
+
+- **UIAutomator2 driver**:
+
+  ```bash
+  appium driver install uiautomator2
+  ```
+
+### Verify Setup
+
+```bash
+appium --version          # Should print 2.x
+appium driver list        # Should show xcuitest and/or uiautomator2
+```
+
+---
+
+## Installation
+
+```bash
+npm install -D @zosmaai/zosma-qa-appium @zosmaai/zosma-qa-core
+```
+
+---
+
+## Project Setup
+
+### 1. Create the config file
+
+```typescript
+// zosma.config.ts
+import { defineConfig } from '@zosmaai/zosma-qa-core';
+
+export default defineConfig({
+  plugins: ['appium'],
+  baseURL: 'localhost',
+  browsers: ['chromium'],
+});
+```
+
+### 2. Create your first test
+
+```typescript
+// tests/login.appium.ts
+import { test } from '@zosmaai/zosma-qa-appium';
+import { tapButton, fillInput, expectText } from '@zosmaai/zosma-qa-appium';
+
+test.describe('Login Flow', () => {
+  test('should login with valid credentials', async ({ driver }) => {
+    await fillInput(driver, 'user@example.com', { testID: 'email-input' });
+    await fillInput(driver, 'password123', { testID: 'password-input' });
+    await tapButton(driver, { testID: 'login-button' });
+    await expectText(driver, 'Welcome back');
+  });
+
+  test('should show error for invalid credentials', async ({ driver }) => {
+    await fillInput(driver, 'wrong@example.com', { testID: 'email-input' });
+    await fillInput(driver, 'wrongpass', { testID: 'password-input' });
+    await tapButton(driver, { testID: 'login-button' });
+    await expectText(driver, 'Invalid credentials');
+  });
+});
+```
+
+### 3. Run your tests
+
+Start Appium in one terminal:
+
+```bash
+appium
+```
+
+Run your tests:
+
+```bash
+npx zosma-qa run
+```
+
+---
+
+## Test File Naming
+
+Appium tests use the `.appium.ts` or `.appium.py` extension to distinguish them from web tests:
+
+```
+tests/
+├── login.appium.ts       ← mobile test (Appium)
+├── navigation.appium.ts  ← mobile test (Appium)
+├── home.spec.ts          ← web test (Playwright)
+└── api.test.ts           ← API test
+```
+
+This convention lets you run web and mobile tests from the same project using different runners.
+
+---
+
+## Test API
+
+### test() function
+
+The test API mirrors Playwright for familiarity:
+
+```typescript
+import { test, expect } from '@zosmaai/zosma-qa-appium';
+
+test.describe('Suite name', () => {
+  test.beforeEach(async ({ driver }) => {
+    // runs before each test
+  });
+
+  test.afterEach(async ({ driver }) => {
+    // runs after each test
+  });
+
+  test('test name', async ({ driver }) => {
+    // driver is a WebdriverIO Browser instance
+  });
+});
+```
+
+### Fixture: `{ driver }`
+
+Every test receives a `driver` fixture — a [WebdriverIO Browser](https://webdriver.io/docs/api/browser) instance connected to your Appium server. Use it for raw WebDriver access:
+
+```typescript
+test('raw WebDriver access', async ({ driver }) => {
+  const el = await driver.$('~my-element');
+  await el.click();
+  const text = await el.getText();
+  expect.toBe(text, 'Hello');
+});
+```
+
+---
+
+## Agent-Friendly Test Helpers
+
+These high-level functions are designed to be readable by both humans and AI agents:
+
+### tapButton
+
+```typescript
+import { tapButton } from '@zosmaai/zosma-qa-appium';
+
+// By testID (recommended for React Native)
+await tapButton(driver, { testID: 'submit-btn' });
+
+// By visible text
+await tapButton(driver, { text: 'Submit' });
+
+// By raw accessibility selector
+await tapButton(driver, '~submit-btn');
+```
+
+### fillInput
+
+```typescript
+import { fillInput } from '@zosmaai/zosma-qa-appium';
+
+await fillInput(driver, 'user@example.com', { testID: 'email-input' });
+await fillInput(driver, 'search term', { text: 'Search' });
+```
+
+### expectText
+
+```typescript
+import { expectText } from '@zosmaai/zosma-qa-appium';
+
+// Assert text is visible on screen
+await expectText(driver, 'Welcome back');
+await expectText(driver, 'Order confirmed');
+```
+
+### waitForElement
+
+```typescript
+import { waitForElement } from '@zosmaai/zosma-qa-appium';
+
+await waitForElement(driver, { testID: 'loading-spinner' }, { timeout: 10000 });
+```
+
+### Gestures
+
+```typescript
+import { swipeDown, swipeUp, scrollToElement } from '@zosmaai/zosma-qa-appium';
+
+await swipeDown(driver);
+await swipeUp(driver);
+await scrollToElement(driver, { testID: 'footer-section' });
+```
+
+### Screenshots
+
+```typescript
+import { takeScreenshot } from '@zosmaai/zosma-qa-appium';
+
+await takeScreenshot(driver, 'login-screen');
+```
+
+---
+
+## Configuration
+
+### Appium-specific options
+
+Create an `appium.config.ts` (optional) alongside your `zosma.config.ts`:
+
+```typescript
+// appium.config.ts
+export default {
+  platformName: 'ReactNative',     // ReactNative | iOS | Android | Flutter
+  appPath: './ios/build/MyApp.app', // auto-detected if omitted
+  appId: 'com.mycompany.myapp',    // auto-detected if omitted
+  deviceName: 'iPhone 15',         // auto-detected if omitted
+  appiumPort: 4723,                // auto-allocated if omitted
+  autoLaunchSimulator: true,       // default: true
+  timeout: 30000,                  // 30s per test
+  workers: 1,                      // mobile tests run serially
+};
+```
+
+### Auto-detection
+
+The runner automatically detects:
+
+| Setting | Detection method |
+|---|---|
+| `appPath` | Scans `ios/build/` and `android/app/build/outputs/apk/` |
+| `appId` | Reads from `package.json`, `AndroidManifest.xml`, or `Info.plist` |
+| `deviceName` | Lists available simulators/emulators |
+| `devServerUrl` | Checks `localhost:8081` for a running Metro bundler |
+| `platformName` | Detects `react-native` in `package.json` dependencies |
+
+### Platform-specific defaults
+
+| Platform | Automation Engine | Default Port |
+|---|---|---|
+| React Native | XCUITest (iOS) | 4723 |
+| iOS | XCUITest | 4723 |
+| Android | UIAutomator2 | 4723 |
+| Flutter | Flutter | 4723 |
+
+---
+
+## Project Structure
+
+A typical mobile testing project:
+
+```
+my-app/
+├── tests/
+│   ├── login.appium.ts
+│   ├── navigation.appium.ts
+│   ├── cart.appium.ts
+│   └── checkout.appium.ts
+├── zosma.config.ts
+├── appium.config.ts        ← optional
+├── package.json
+└── ios/                    ← React Native app
+    └── build/
+        └── MyApp.app
+```
+
+---
+
+## Troubleshooting
+
+### Appium server won't start
+
+```bash
+# Check if Appium is installed
+appium --version
+
+# Check if drivers are installed
+appium driver list
+
+# Start with debug logging
+appium --log-level debug
+```
+
+### Simulator not found
+
+```bash
+# List available iOS simulators
+xcrun simctl list devices
+
+# List available Android emulators
+emulator -list-avds
+```
+
+### Test timeout
+
+Increase the timeout in your config:
+
+```typescript
+// appium.config.ts
+export default {
+  timeout: 60000,  // 60 seconds
+};
+```
+
+### Port conflict
+
+The runner auto-allocates ports, but you can specify one:
+
+```typescript
+// appium.config.ts
+export default {
+  appiumPort: 4724,  // use a different port
+};
+```
+
+---
+
+## Example Project
+
+See [`examples/appium-demo/`](../examples/appium-demo/) for a complete example project with sample tests.
+
+---
+
+## Next Steps
+
+- Explore the [Appium package README](../packages/appium/README.md) for the full API reference
+- Read about [web testing with Playwright](GETTING_STARTED_PLAYWRIGHT.md)
+- Read the [Architecture](ARCHITECTURE.md) doc for how the packages fit together
+- Read the [Vision](VISION.md) doc for the project roadmap

--- a/docs/GETTING_STARTED_LOAD_TESTING.md
+++ b/docs/GETTING_STARTED_LOAD_TESTING.md
@@ -1,0 +1,94 @@
+# Getting Started with Load Testing (k6 / Artillery)
+
+> **Status: Planned** — Load testing support is on the zosma-qa roadmap but not yet implemented.
+
+---
+
+## What's Coming
+
+zosma-qa will support load and performance testing through two popular tools:
+
+| Runner | Package | Use Case |
+|---|---|---|
+| **k6** | `@zosmaai/zosma-qa-k6` | Developer-centric load testing with JavaScript |
+| **Artillery** | `@zosmaai/zosma-qa-artillery` | YAML-first load testing with rich scenarios |
+
+Both will follow the same plugin pattern as the Playwright and Appium runners — implement `ZosmaPlugin`, configure in `zosma.config.ts`, run with `npx zosma-qa run`.
+
+---
+
+## Planned Features
+
+### k6 Integration
+
+- Write load tests in JavaScript/TypeScript
+- Configure via `zosma.config.ts` with `plugins: ['k6']`
+- Run with `npx zosma-qa run` (dispatches to `k6 run`)
+- Results aggregated into the unified report dashboard
+
+```typescript
+// Example: future k6 test
+// tests/load/homepage.k6.ts
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 50,
+  duration: '30s',
+};
+
+export default function () {
+  const res = http.get('https://www.myapp.com');
+  check(res, { 'status is 200': (r) => r.status === 200 });
+  sleep(1);
+}
+```
+
+### Artillery Integration
+
+- YAML-based test scenarios
+- Configure via `zosma.config.ts` with `plugins: ['artillery']`
+- Run with `npx zosma-qa run` (dispatches to `artillery run`)
+- Support for HTTP, WebSocket, and Socket.IO protocols
+
+```yaml
+# Example: future Artillery test
+# tests/load/homepage.artillery.yml
+config:
+  target: "https://www.myapp.com"
+  phases:
+    - duration: 30
+      arrivalRate: 10
+scenarios:
+  - flow:
+      - get:
+          url: "/"
+          expect:
+            - statusCode: 200
+```
+
+---
+
+## Roadmap
+
+Load testing is part of **Phase 2** in the [zosma-qa Vision](VISION.md). The implementation order:
+
+1. k6 plugin (JavaScript-native, aligns with TypeScript ecosystem)
+2. Artillery plugin (YAML-first, broader protocol support)
+3. Unified reporting (load metrics alongside E2E and mobile test results)
+
+---
+
+## Want to Contribute?
+
+If you're interested in building the k6 or Artillery plugin, see:
+
+- [Architecture](ARCHITECTURE.md) — how plugins work
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — development setup and guidelines
+- The existing [`@zosmaai/zosma-qa-appium`](../packages/appium/) package as a reference for building a new runner plugin
+
+---
+
+## Stay Updated
+
+Watch the [zosma-qa repository](https://github.com/zosmaai/zosma-qa) for updates on load testing support.

--- a/docs/GETTING_STARTED_PLAYWRIGHT.md
+++ b/docs/GETTING_STARTED_PLAYWRIGHT.md
@@ -1,0 +1,237 @@
+# Getting Started with Playwright (Web Testing)
+
+This guide covers setting up zosma-qa for browser-based end-to-end and component testing using Playwright.
+
+---
+
+## Prerequisites
+
+- **Node.js** >= 18
+- **npm**, **pnpm**, or **yarn**
+
+---
+
+## Option A: Interactive Setup (Recommended)
+
+```bash
+npx zosma-qa init
+```
+
+The CLI will prompt you for:
+
+1. **Project name** — leave blank to scaffold in the current directory
+2. **Language** — choose TypeScript
+3. **Base URL** — the URL of the app you want to test (e.g., `https://www.myapp.com`)
+4. **Browsers** — chromium (default), firefox, webkit
+5. **AI agents** — OpenCode (default), Claude Code, VS Code, or skip
+
+This creates:
+
+```
+tests/seed.spec.ts         ← starter test + AI agent entry point
+specs/.gitkeep             ← AI planner output directory
+playwright.config.ts       ← extends @zosmaai/zosma-qa-playwright base config
+zosma.config.ts            ← top-level zosma-qa config
+.github/agents/.gitkeep    ← AI agent definitions directory
+package.json               ← created if missing, deps installed automatically
+```
+
+### Run your tests
+
+```bash
+npx zosma-qa run
+```
+
+### Open the report
+
+```bash
+npx zosma-qa report
+```
+
+---
+
+## Option B: Add to an Existing Project
+
+```bash
+npm install -D @zosmaai/zosma-qa-playwright @playwright/test
+npx playwright install
+```
+
+Create a `playwright.config.ts`:
+
+```typescript
+import { defineConfig } from '@zosmaai/zosma-qa-playwright';
+
+export default defineConfig({
+  use: {
+    baseURL: 'https://www.myapp.com',
+  },
+  browsers: ['chromium', 'firefox', 'webkit'],
+});
+```
+
+The `defineConfig()` function wraps Playwright's config with production-ready defaults:
+
+| Setting | CI | Local |
+|---|---|---|
+| `fullyParallel` | `true` | `true` |
+| `retries` | `2` | `0` |
+| `workers` | `1` | auto |
+| `reporter` | html + github + list | html + list |
+| `trace` | on-first-retry | on-first-retry |
+| `screenshot` | only-on-failure | only-on-failure |
+| `video` | retain-on-failure | retain-on-failure |
+
+All standard Playwright options are supported — override anything you need:
+
+```typescript
+export default defineConfig({
+  use: { baseURL: 'https://staging.myapp.com' },
+  browsers: ['chromium'],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+  testDir: './e2e',
+});
+```
+
+---
+
+## Writing Tests
+
+### Standard test structure
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Login page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('should display login form', async ({ page }) => {
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/password/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
+  });
+
+  test('should login with valid credentials', async ({ page }) => {
+    await page.getByLabel(/email/i).fill('user@example.com');
+    await page.getByLabel(/password/i).fill('password123');
+    await page.getByRole('button', { name: /sign in/i }).click();
+    await expect(page).toHaveURL('/dashboard');
+  });
+});
+```
+
+### File naming
+
+Tests must match one of these patterns to be discovered:
+
+- `*.spec.ts` / `*.spec.js`
+- `*.test.ts` / `*.test.js`
+
+Place them in your `testDir` (default: `./tests`).
+
+---
+
+## Python (pytest-playwright)
+
+```bash
+npx zosma-qa init
+# Choose: Python
+```
+
+If [uv](https://docs.astral.sh/uv/) is installed, dependencies are installed automatically. Otherwise the CLI prints instructions for `venv + pip`.
+
+```bash
+playwright install
+npx zosma-qa run
+```
+
+Python tests use pytest-playwright's `page` fixture:
+
+```python
+# tests/test_login.py
+import re
+from playwright.sync_api import Page, expect
+
+def test_login_page(page: Page):
+    page.goto("/login")
+    expect(page.get_by_label(re.compile("email", re.IGNORECASE))).to_be_visible()
+    expect(page.get_by_role("button", name=re.compile("sign in", re.IGNORECASE))).to_be_visible()
+```
+
+---
+
+## AI Agents
+
+### Setup
+
+```bash
+npx zosma-qa agents init
+# Choose: OpenCode (default) / Claude Code / VS Code
+```
+
+This runs `npx playwright init-agents` and generates agent definitions in `.github/agents/`.
+
+### Workflow
+
+1. **Plan** — The planner agent explores your app and writes a Markdown test plan:
+
+   ```
+   Use the planner agent. Seed: tests/seed.spec.ts.
+   Generate a plan for the checkout flow.
+   ```
+
+2. **Generate** — The generator agent turns a plan into test files:
+
+   ```
+   Use the generator agent with specs/checkout.md
+   ```
+
+3. **Heal** — The healer agent fixes broken locators and assertions:
+
+   ```
+   Use the healer agent on tests/checkout/add-to-cart.spec.ts
+   ```
+
+> AI agents are currently TypeScript-only.
+
+---
+
+## CLI Commands
+
+| Command | Description |
+|---|---|
+| `npx zosma-qa init` | Interactive scaffold |
+| `npx zosma-qa run` | Run all tests |
+| `npx zosma-qa run --grep "checkout"` | Filter by pattern |
+| `npx zosma-qa run --headed` | Visible browser mode |
+| `npx zosma-qa run --project firefox` | Run specific browser |
+| `npx zosma-qa agents init` | Set up AI agents |
+| `npx zosma-qa report` | Open HTML report |
+
+All flags are forwarded directly to `npx playwright test`.
+
+---
+
+## Example Project
+
+See [`examples/zosma-ai/`](../examples/zosma-ai/) for a complete working test suite that runs against the live [zosma.ai](https://www.zosma.ai) site.
+
+```bash
+# From the repo root
+pnpm test:examples
+```
+
+---
+
+## Next Steps
+
+- Read the [Architecture](ARCHITECTURE.md) doc for how the packages fit together
+- Read the [Vision](VISION.md) doc for the project roadmap
+- Explore [mobile testing with Appium](GETTING_STARTED_APPIUM.md) for iOS and Android

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -35,14 +35,15 @@ zosma-qa aims to be the last QA bootstrap you ever write.
 The plugin interface in `@zosmaai/zosma-qa-core` makes adding new runners straightforward.
 Planned plugins:
 
-| Plugin | Test type | Underlying tool |
-|---|---|---|
-| `@zosmaai/zosma-qa-rest` | REST API testing | Supertest / Pactum |
-| `@zosmaai/zosma-qa-k6` | Load testing | k6 |
-| `@zosmaai/zosma-qa-artillery` | Load testing | Artillery |
-| `@zosmaai/zosma-qa-accessibility` | Accessibility | axe-core + Playwright |
-| `@zosmaai/zosma-qa-contract` | Contract testing | Pact |
-| `@zosmaai/zosma-qa-visual` | Visual regression | Percy / Chromatic |
+| Plugin | Test type | Underlying tool | Status |
+|---|---|---|---|
+| `@zosmaai/zosma-qa-appium` | Mobile testing (iOS & Android) | Appium + WebdriverIO | **Available** |
+| `@zosmaai/zosma-qa-rest` | REST API testing | Supertest / Pactum | Planned |
+| `@zosmaai/zosma-qa-k6` | Load testing | k6 | Planned |
+| `@zosmaai/zosma-qa-artillery` | Load testing | Artillery | Planned |
+| `@zosmaai/zosma-qa-accessibility` | Accessibility | axe-core + Playwright | Planned |
+| `@zosmaai/zosma-qa-contract` | Contract testing | Pact | Planned |
+| `@zosmaai/zosma-qa-visual` | Visual regression | Percy / Chromatic | Planned |
 
 Each plugin follows the same pattern: implement `ZosmaPlugin`, add a config
 file, and wire it into `zosma.config.ts`. Users run everything with a single

--- a/examples/appium-demo/README.md
+++ b/examples/appium-demo/README.md
@@ -1,0 +1,120 @@
+# Appium Demo — Example Mobile Tests
+
+This example project demonstrates how to write mobile tests with `@zosmaai/zosma-qa-appium`. The tests show the API patterns, test helpers, and project structure for a React Native app.
+
+> **Note:** These example tests are for demonstration purposes. To run them against a real app, you'll need Appium installed, a simulator/emulator running, and the app built and deployed.
+
+---
+
+## Prerequisites
+
+1. **Node.js** >= 18
+2. **Appium** >= 2.0:
+
+   ```bash
+   npm install -g appium
+   appium driver install xcuitest       # iOS
+   appium driver install uiautomator2   # Android
+   ```
+
+3. **iOS:** Xcode + Xcode Command Line Tools
+4. **Android:** Android Studio + Android SDK + `ANDROID_HOME` set
+
+---
+
+## Project Structure
+
+```
+examples/appium-demo/
+├── tests/
+│   ├── login.appium.ts         ← Login flow tests
+│   ├── navigation.appium.ts    ← Tab and screen navigation tests
+│   └── profile.appium.ts       ← User profile tests
+├── zosma.config.ts             ← zosma-qa config (plugins: ['appium'])
+├── package.json
+└── README.md                   ← this file
+```
+
+---
+
+## Running the Examples
+
+### 1. Install dependencies
+
+```bash
+cd examples/appium-demo
+npm install
+```
+
+### 2. Start Appium
+
+```bash
+appium
+```
+
+### 3. Launch a simulator
+
+```bash
+# iOS
+xcrun simctl boot "iPhone 15"
+
+# Android
+emulator -avd Pixel_7_API_34
+```
+
+### 4. Build and install your app on the simulator
+
+```bash
+# React Native (iOS)
+npx react-native run-ios
+
+# React Native (Android)
+npx react-native run-android
+```
+
+### 5. Run the tests
+
+```bash
+npx zosma-qa run
+```
+
+---
+
+## What the Tests Demonstrate
+
+### `tests/login.appium.ts`
+- Filling text inputs by `testID`
+- Tapping buttons
+- Asserting visible text after navigation
+- Error state validation
+- Using `beforeEach` hooks for test isolation
+
+### `tests/navigation.appium.ts`
+- Tab bar navigation
+- Screen transitions
+- Waiting for elements to appear
+- Swipe gestures
+- Back navigation
+
+### `tests/profile.appium.ts`
+- Reading element text
+- Scrolling to off-screen elements
+- Taking screenshots
+- Raw WebDriver access via `driver.$()` escape hatch
+
+---
+
+## Adapting for Your App
+
+1. Update `zosma.config.ts` with your app's base URL
+2. Replace `testID` values with your app's actual test IDs
+3. Update assertions to match your app's UI text
+4. Add additional test files following the `.appium.ts` naming pattern
+
+---
+
+## Learn More
+
+- [Getting Started with Appium](../../docs/GETTING_STARTED_APPIUM.md) — full setup guide
+- [Appium Package README](../../packages/appium/README.md) — API reference
+- [Getting Started with Playwright](../../docs/GETTING_STARTED_PLAYWRIGHT.md) — web testing

--- a/examples/appium-demo/package.json
+++ b/examples/appium-demo/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "appium-demo-example",
+  "version": "0.1.0",
+  "description": "Example Appium mobile tests — shows the zosma-qa Appium workflow",
+  "private": true,
+  "scripts": {
+    "test": "zosma-qa run"
+  },
+  "devDependencies": {
+    "@zosmaai/zosma-qa-appium": "workspace:*",
+    "@zosmaai/zosma-qa-core": "workspace:*",
+    "appium": ">=2.0.0"
+  }
+}

--- a/examples/appium-demo/tests/login.appium.ts
+++ b/examples/appium-demo/tests/login.appium.ts
@@ -1,0 +1,75 @@
+/**
+ * Login flow tests — demonstrates filling inputs, tapping buttons,
+ * asserting visible text, and error-state validation.
+ */
+import {
+  expect,
+  expectText,
+  expectVisible,
+  fillInput,
+  resetApp,
+  tapButton,
+  test,
+} from '@zosmaai/zosma-qa-appium';
+
+test.describe('Login', () => {
+  test.beforeEach(async ({ driver }) => {
+    await resetApp(driver);
+  });
+
+  test('shows login screen on launch', async ({ driver }) => {
+    await expectVisible(driver, { testID: 'login-screen' });
+    await expectText(driver, 'Welcome Back');
+  });
+
+  test('can log in with valid credentials', async ({ driver }) => {
+    await fillInput(driver, 'demo@example.com', { testID: 'email-input' });
+    await fillInput(driver, 'password123', { testID: 'password-input' });
+    await tapButton(driver, { testID: 'login-button' });
+
+    // Should navigate to home screen after login
+    await expectVisible(driver, { testID: 'home-screen' }, { timeout: 5000 });
+    await expectText(driver, 'Dashboard');
+  });
+
+  test('shows error for invalid credentials', async ({ driver }) => {
+    await fillInput(driver, 'bad@example.com', { testID: 'email-input' });
+    await fillInput(driver, 'wrong', { testID: 'password-input' });
+    await tapButton(driver, { testID: 'login-button' });
+
+    await expectText(driver, 'Invalid email or password', { timeout: 3000 });
+    // Should stay on login screen
+    await expectVisible(driver, { testID: 'login-screen' });
+  });
+
+  test('validates required fields', async ({ driver }) => {
+    // Tap login without filling fields
+    await tapButton(driver, { testID: 'login-button' });
+
+    await expectText(driver, 'Email is required');
+    await expectText(driver, 'Password is required');
+  });
+
+  test('navigates to forgot password', async ({ driver }) => {
+    await tapButton(driver, { text: 'Forgot Password?' });
+    await expectVisible(driver, { testID: 'forgot-password-screen' });
+    await expectText(driver, 'Reset Password');
+  });
+
+  test('navigates to sign up', async ({ driver }) => {
+    await tapButton(driver, { text: 'Sign Up' });
+    await expectVisible(driver, { testID: 'signup-screen' });
+    await expectText(driver, 'Create Account');
+
+    // Verify all signup fields are present
+    await expectVisible(driver, { testID: 'name-input' });
+    await expectVisible(driver, { testID: 'email-input' });
+    await expectVisible(driver, { testID: 'password-input' });
+    await expectVisible(driver, { testID: 'confirm-password-input' });
+  });
+
+  test.afterEach(async ({ driver }) => {
+    // Capture state for debugging if a test fails
+    expect.toBeTruthy(driver);
+  });
+});

--- a/examples/appium-demo/tests/navigation.appium.ts
+++ b/examples/appium-demo/tests/navigation.appium.ts
@@ -1,0 +1,102 @@
+/**
+ * Tab and screen navigation tests — demonstrates tapping tabs,
+ * waiting for elements, swipe gestures, and back navigation.
+ */
+import {
+  expectText,
+  expectVisible,
+  fillInput,
+  goBack,
+  swipeDown,
+  swipeLeft,
+  tapButton,
+  test,
+  waitForElement,
+} from '@zosmaai/zosma-qa-appium';
+
+test.describe('Navigation', () => {
+  test.beforeEach(async ({ driver }) => {
+    // Log in before each test to reach the main app
+    await fillInput(driver, 'demo@example.com', { testID: 'email-input' });
+    await fillInput(driver, 'password123', { testID: 'password-input' });
+    await tapButton(driver, { testID: 'login-button' });
+    await waitForElement(driver, '~home-screen', 5000);
+  });
+
+  test('shows bottom tab bar with all tabs', async ({ driver }) => {
+    await expectVisible(driver, { testID: 'tab-bar' });
+    await expectText(driver, 'Home');
+    await expectText(driver, 'Search');
+    await expectText(driver, 'Notifications');
+    await expectText(driver, 'Profile');
+  });
+
+  test('navigates to Search tab', async ({ driver }) => {
+    await tapButton(driver, { testID: 'tab-search' });
+    await expectVisible(driver, { testID: 'search-screen' });
+    await expectVisible(driver, { testID: 'search-input' });
+    await expectText(driver, 'Search');
+  });
+
+  test('navigates to Notifications tab', async ({ driver }) => {
+    await tapButton(driver, { testID: 'tab-notifications' });
+    await expectVisible(driver, { testID: 'notifications-screen' });
+    await expectText(driver, 'Notifications');
+  });
+
+  test('navigates to Profile tab', async ({ driver }) => {
+    await tapButton(driver, { testID: 'tab-profile' });
+    await expectVisible(driver, { testID: 'profile-screen' });
+    await expectText(driver, 'Profile');
+  });
+
+  test('navigates back from detail screen', async ({ driver }) => {
+    // Tap a list item to go to a detail screen
+    await tapButton(driver, { testID: 'item-1' });
+    await waitForElement(driver, '~detail-screen', 3000);
+    await expectVisible(driver, { testID: 'detail-screen' });
+
+    // Go back
+    await goBack(driver);
+    await expectVisible(driver, { testID: 'home-screen' });
+  });
+
+  test('pull-to-refresh on home screen', async ({ driver }) => {
+    await expectVisible(driver, { testID: 'home-screen' });
+
+    // Pull down to trigger refresh
+    await swipeDown(driver, { distance: 300, duration: 500 });
+
+    // Wait for refresh indicator to disappear
+    await waitForElement(driver, '~home-list', 5000);
+  });
+
+  test('swipe through onboarding cards', async ({ driver }) => {
+    // Navigate to a screen with horizontal swipe cards
+    await tapButton(driver, { testID: 'onboarding-link' });
+    await waitForElement(driver, '~onboarding-screen', 3000);
+
+    // Swipe through cards
+    await expectText(driver, 'Step 1');
+    await swipeLeft(driver, { distance: 250, duration: 300 });
+    await expectText(driver, 'Step 2');
+    await swipeLeft(driver, { distance: 250, duration: 300 });
+    await expectText(driver, 'Step 3');
+  });
+
+  test('deep link navigation preserves back stack', async ({ driver }) => {
+    // Navigate: Home → Search → Item Detail
+    await tapButton(driver, { testID: 'tab-search' });
+    await fillInput(driver, 'test query', { testID: 'search-input' });
+    await tapButton(driver, { testID: 'search-result-1' });
+    await expectVisible(driver, { testID: 'detail-screen' });
+
+    // Going back should return to search, not home
+    await goBack(driver);
+    await expectVisible(driver, { testID: 'search-screen' });
+
+    // Going back again should return to home
+    await goBack(driver);
+    await expectVisible(driver, { testID: 'home-screen' });
+  });
+});

--- a/examples/appium-demo/tests/profile.appium.ts
+++ b/examples/appium-demo/tests/profile.appium.ts
@@ -1,0 +1,98 @@
+/**
+ * User profile tests — demonstrates reading element text, scrolling
+ * to off-screen elements, taking screenshots, and raw WebDriver access.
+ */
+import {
+  expect,
+  expectText,
+  expectVisible,
+  fillInput,
+  swipeUp,
+  takeScreenshot,
+  tapButton,
+  test,
+  waitForElement,
+} from '@zosmaai/zosma-qa-appium';
+
+test.describe('Profile', () => {
+  test.beforeEach(async ({ driver }) => {
+    // Log in and navigate to Profile tab
+    await fillInput(driver, 'demo@example.com', { testID: 'email-input' });
+    await fillInput(driver, 'password123', { testID: 'password-input' });
+    await tapButton(driver, { testID: 'login-button' });
+    await waitForElement(driver, '~home-screen', 5000);
+    await tapButton(driver, { testID: 'tab-profile' });
+    await waitForElement(driver, '~profile-screen', 3000);
+  });
+
+  test('shows user profile information', async ({ driver }) => {
+    await expectVisible(driver, { testID: 'profile-screen' });
+    await expectText(driver, 'demo@example.com');
+    await expectVisible(driver, { testID: 'profile-avatar' });
+    await expectVisible(driver, { testID: 'profile-name' });
+  });
+
+  test('edits display name', async ({ driver }) => {
+    await tapButton(driver, { testID: 'edit-profile-button' });
+    await expectVisible(driver, { testID: 'edit-profile-screen' });
+
+    await fillInput(driver, 'New Display Name', { testID: 'display-name-input' });
+    await tapButton(driver, { testID: 'save-profile-button' });
+
+    // Should return to profile with updated name
+    await expectVisible(driver, { testID: 'profile-screen' });
+    await expectText(driver, 'New Display Name');
+  });
+
+  test('scrolls to settings section', async ({ driver }) => {
+    // Settings section is below the fold
+    await swipeUp(driver, { distance: 400, duration: 500 });
+    await swipeUp(driver, { distance: 400, duration: 500 });
+
+    await expectVisible(driver, { testID: 'settings-section' });
+    await expectText(driver, 'Settings');
+    await expectText(driver, 'Notifications');
+    await expectText(driver, 'Privacy');
+    await expectText(driver, 'About');
+  });
+
+  test('takes profile screenshot', async ({ driver }) => {
+    const path = await takeScreenshot(driver, 'profile');
+    expect.toBeTruthy(path);
+    // Screenshot is saved locally — path should contain 'profile'
+    expect.toBeTruthy(path.includes('profile'));
+  });
+
+  test('toggles dark mode from settings', async ({ driver }) => {
+    // Scroll to settings
+    await swipeUp(driver, { distance: 400, duration: 500 });
+    await swipeUp(driver, { distance: 400, duration: 500 });
+
+    await tapButton(driver, { testID: 'dark-mode-toggle' });
+
+    // Take a screenshot of dark mode for visual comparison
+    await takeScreenshot(driver, 'profile-dark-mode');
+  });
+
+  test('logs out from profile', async ({ driver }) => {
+    // Scroll down to find logout button
+    await swipeUp(driver, { distance: 500, duration: 500 });
+
+    await tapButton(driver, { testID: 'logout-button' });
+
+    // Should return to login screen
+    await expectVisible(driver, { testID: 'login-screen' }, { timeout: 3000 });
+    await expectText(driver, 'Welcome Back');
+  });
+
+  test('uses raw WebDriver for custom assertion', async ({ driver }) => {
+    // Escape hatch: use driver.$() directly for advanced scenarios
+    // This demonstrates that the full WebDriver API is available
+    const avatar = await driver.$('~profile-avatar');
+    expect.toBeTruthy(avatar);
+
+    // Check element attributes via raw WebDriver
+    const isDisplayed = await (avatar as { isDisplayed: () => Promise<boolean> }).isDisplayed();
+    expect.toBeTruthy(isDisplayed);
+  });
+});

--- a/examples/appium-demo/zosma.config.ts
+++ b/examples/appium-demo/zosma.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@zosmaai/zosma-qa-core';
+
+export default defineConfig({
+  plugins: ['appium'],
+  baseURL: 'http://localhost:4723',
+  browsers: ['chromium'], // ignored by Appium — required by config schema
+});

--- a/packages/appium/README.md
+++ b/packages/appium/README.md
@@ -1,0 +1,149 @@
+# @zosmaai/zosma-qa-appium
+
+Appium mobile testing runner for [zosma-qa](https://github.com/zosmaai/zosma-qa) — the open-source QA platform for Web, Mobile, Backend, and Load testing.
+
+This package provides a Playwright-like test API for mobile apps, powered by WebdriverIO and Appium. It includes agent-friendly test helpers, automatic device detection, and zero-config defaults for React Native projects.
+
+## Installation
+
+```bash
+npm install -D @zosmaai/zosma-qa-appium
+```
+
+**Peer dependency:** You'll need Appium installed globally or locally:
+
+```bash
+npm install -g appium
+appium driver install uiautomator2   # Android
+appium driver install xcuitest       # iOS
+```
+
+## Usage
+
+### Write a test
+
+```typescript
+// tests/login.appium.ts
+import { test } from '@zosmaai/zosma-qa-appium';
+import { tapButton, fillInput, expectText } from '@zosmaai/zosma-qa-appium';
+
+test.describe('Login Flow', () => {
+  test.beforeEach(async ({ driver }) => {
+    // driver is a WebdriverIO Browser instance
+  });
+
+  test('should login with valid credentials', async ({ driver }) => {
+    await fillInput(driver, 'user@example.com', { testID: 'email-input' });
+    await fillInput(driver, 'password123', { testID: 'password-input' });
+    await tapButton(driver, { testID: 'login-button' });
+    await expectText(driver, 'Welcome back');
+  });
+});
+```
+
+### Configure
+
+```typescript
+// zosma.config.ts
+import { defineConfig } from '@zosmaai/zosma-qa-core';
+
+export default defineConfig({
+  plugins: ['appium'],
+  baseURL: 'localhost',
+  browsers: ['chromium'],
+});
+```
+
+## Features
+
+| Feature | Description |
+|---|---|
+| **Playwright-like API** | `test()`, `test.describe()`, `test.beforeEach()`, `test.afterEach()` |
+| **Fixture injection** | Tests receive `{ driver }` — a WebdriverIO Browser instance |
+| **Agent-friendly helpers** | `tapButton()`, `fillInput()`, `swipeDown()`, `expectText()`, `waitForElement()` |
+| **Auto-detection** | Finds app path, app ID, and dev server automatically for React Native projects |
+| **Session management** | Handles WebdriverIO session lifecycle with retry and cleanup |
+| **Device management** | iOS Simulator and Android Emulator detection and control |
+| **Server management** | Starts and stops Appium server automatically with port allocation |
+| **Multi-platform** | React Native, iOS, Android, Flutter, React Native Web |
+
+## Test Helpers
+
+High-level, agent-readable functions that wrap raw WebDriver calls:
+
+```typescript
+import {
+  tapButton,       // Tap a button by testID or text
+  fillInput,       // Fill a text input
+  expectText,      // Assert text is visible on screen
+  waitForElement,  // Wait for an element to appear
+  swipeDown,       // Swipe down gesture
+  swipeUp,         // Swipe up gesture
+  scrollToElement, // Scroll until element is visible
+  takeScreenshot,  // Capture screenshot
+} from '@zosmaai/zosma-qa-appium';
+```
+
+Each helper supports multiple locator strategies:
+
+```typescript
+// By testID (recommended)
+await tapButton(driver, { testID: 'submit-btn' });
+
+// By visible text
+await tapButton(driver, { text: 'Submit' });
+
+// By raw selector
+await tapButton(driver, '~submit-btn');
+```
+
+## Platform Support
+
+| Platform | Automation Engine | Status |
+|---|---|---|
+| React Native | XCUITest (iOS) / UIAutomator2 (Android) | Available |
+| iOS Native | XCUITest | Available |
+| Android Native | UIAutomator2 | Available |
+| Flutter | Flutter driver | Available |
+| React Native Web | Chromium | Available |
+
+## Smart Defaults
+
+The runner applies sensible defaults so you can start testing without configuration:
+
+| Setting | Default | Notes |
+|---|---|---|
+| `platformName` | `ReactNative` | Auto-detected from project |
+| `appiumPort` | `4723` | Auto-allocated if busy |
+| `appiumHost` | `localhost` | |
+| `testDir` | `./tests` | |
+| `workers` | `1` | Mobile tests run serially |
+| `timeout` | `30000` | 30 seconds per test |
+| `autoLaunchSimulator` | `true` | Launches simulator if needed |
+
+## Advanced: Raw WebDriver Access
+
+The `driver` fixture is a standard WebdriverIO `Browser` instance. Use it directly for anything the helpers don't cover:
+
+```typescript
+test('advanced interaction', async ({ driver }) => {
+  const element = await driver.$('~my-element');
+  await element.click();
+
+  const text = await element.getText();
+  expect.toBe(text, 'Expected value');
+});
+```
+
+## Part of zosma-qa
+
+- [`@zosmaai/zosma-qa-core`](https://www.npmjs.com/package/@zosmaai/zosma-qa-core) — shared types and plugin interface
+- [`@zosmaai/zosma-qa-playwright`](https://www.npmjs.com/package/@zosmaai/zosma-qa-playwright) — Playwright runner and base config
+- [`@zosmaai/zosma-qa-cli`](https://www.npmjs.com/package/@zosmaai/zosma-qa-cli) — interactive CLI (`npx zosma-qa`)
+- [`@zosmaai/zosma-qa-appium`](https://www.npmjs.com/package/@zosmaai/zosma-qa-appium) — this package
+
+Full documentation: [github.com/zosmaai/zosma-qa](https://github.com/zosmaai/zosma-qa)
+
+## License
+
+Apache-2.0

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -54,6 +54,7 @@ Generate a plan for the guest checkout flow.
 
 - [`@zosmaai/zosma-qa-core`](https://www.npmjs.com/package/@zosmaai/zosma-qa-core) — shared types and plugin interface
 - [`@zosmaai/zosma-qa-playwright`](https://www.npmjs.com/package/@zosmaai/zosma-qa-playwright) — Playwright runner and base config
+- [`@zosmaai/zosma-qa-appium`](https://www.npmjs.com/package/@zosmaai/zosma-qa-appium) — Appium mobile testing runner
 - [`@zosmaai/zosma-qa-cli`](https://www.npmjs.com/package/@zosmaai/zosma-qa-cli) — this package
 
 Full documentation: [github.com/zosmaai/zosma-qa](https://github.com/zosmaai/zosma-qa)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -48,6 +48,7 @@ export class MyRunner implements ZosmaPlugin {
 
 - [`@zosmaai/zosma-qa-core`](https://www.npmjs.com/package/@zosmaai/zosma-qa-core) — this package
 - [`@zosmaai/zosma-qa-playwright`](https://www.npmjs.com/package/@zosmaai/zosma-qa-playwright) — Playwright runner and base config
+- [`@zosmaai/zosma-qa-appium`](https://www.npmjs.com/package/@zosmaai/zosma-qa-appium) — Appium mobile testing runner
 - [`@zosmaai/zosma-qa-cli`](https://www.npmjs.com/package/@zosmaai/zosma-qa-cli) — interactive CLI (`npx zosma-qa`)
 
 Full documentation: [github.com/zosmaai/zosma-qa](https://github.com/zosmaai/zosma-qa)

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -67,6 +67,7 @@ export default defineConfig({
 
 - [`@zosmaai/zosma-qa-core`](https://www.npmjs.com/package/@zosmaai/zosma-qa-core) — shared types and plugin interface
 - [`@zosmaai/zosma-qa-playwright`](https://www.npmjs.com/package/@zosmaai/zosma-qa-playwright) — this package
+- [`@zosmaai/zosma-qa-appium`](https://www.npmjs.com/package/@zosmaai/zosma-qa-appium) — Appium mobile testing runner
 - [`@zosmaai/zosma-qa-cli`](https://www.npmjs.com/package/@zosmaai/zosma-qa-cli) — interactive CLI (`npx zosma-qa`)
 
 Full documentation: [github.com/zosmaai/zosma-qa](https://github.com/zosmaai/zosma-qa)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,18 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
 
+  examples/appium-demo:
+    devDependencies:
+      '@zosmaai/zosma-qa-appium':
+        specifier: workspace:*
+        version: link:../../packages/appium
+      '@zosmaai/zosma-qa-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      appium:
+        specifier: '>=2.0.0'
+        version: 3.2.2
+
   examples/zosma-ai:
     devDependencies:
       '@playwright/test':


### PR DESCRIPTION
## Summary

Rebrands zosma-qa from a Playwright-only tool to a **full QA platform** (Web, Mobile, Backend, Load Testing) and wires Appium into the release pipeline so it publishes automatically with the next `v*` tag.

**Key changes:**

- **Root README** rewritten — packages table, npm badges, sections for Playwright / Appium / Python / Load Testing
- **New docs** — dedicated getting-started guides for Playwright, Appium, and Load Testing (placeholder)
- **Updated docs** — ARCHITECTURE.md (dependency graph, appium module table, test discovery), VISION.md (Appium marked "Available" in Phase 2)
- **Package READMEs** — created `packages/appium/README.md`; added Appium to "Part of zosma-qa" footer in core, playwright, cli
- **Example project** — `examples/appium-demo/` with 3 test files (login, navigation, profile) demonstrating the Appium test API
- **Release workflow** — added Appium version bump + publish step to `release.yml`

No runtime code changes. Documentation and CI only.

## Related issue

Part of the Appium runner initiative (Phase 1: #15, Phase 2: #16).

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (64 files, 0 issues)
- [x] Tests added or updated (if applicable)
- [x] Documentation updated (if applicable)
