### PR TITLE
feat(k6): add k6 load testing plugin and resolve upstream merge conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ zosma-qa is a unified QA framework that gives you production-ready test infrastr
 |---|---|---|
 | **Web (E2E & Component)** | Playwright | Available |
 | **Mobile (iOS & Android)** | Appium + WebdriverIO | Available |
-| **Load & Performance** | k6 / Artillery | Planned |
+| **Load & Performance** | k6 | Available |
+| **Load & Performance** | Artillery | Planned |
 | **REST API** | Supertest / Pactum | Planned |
 | **Accessibility** | axe-core + Playwright | Planned |
 | **Visual Regression** | Percy / Chromatic | Planned |
@@ -42,6 +43,7 @@ zosma-qa is a unified QA framework that gives you production-ready test infrastr
 | [`@zosmaai/zosma-qa-playwright`](packages/playwright/) | [![npm](https://img.shields.io/npm/v/@zosmaai/zosma-qa-playwright)](https://www.npmjs.com/package/@zosmaai/zosma-qa-playwright) | Playwright runner and base config |
 | [`@zosmaai/zosma-qa-cli`](packages/cli/) | [![npm](https://img.shields.io/npm/v/@zosmaai/zosma-qa-cli)](https://www.npmjs.com/package/@zosmaai/zosma-qa-cli) | Interactive CLI with prompts |
 | [`@zosmaai/zosma-qa-appium`](packages/appium/) | *Publishing with next release* | Appium mobile testing runner |
+| [`@zosmaai/zosma-qa-k6`](packages/k6/) | *Publishing with next release* | k6 load testing runner |
 
 ---
 
@@ -139,9 +141,30 @@ zosma.config.ts      ← plugins: ['pytest']
 
 ---
 
-### Load Testing (k6 / Artillery) — Planned
+### Load Testing (k6)
 
-Load testing support via k6 and Artillery is on the roadmap. See [Load Testing](docs/GETTING_STARTED_LOAD_TESTING.md) for status and planned features.
+```bash
+npm install -D @zosmaai/zosma-qa-k6
+```
+
+```typescript
+// zosma.config.ts
+import { defineConfig } from '@zosmaai/zosma-qa-core';
+
+export default defineConfig({
+  plugins: ['k6'],
+  testDir: './k6',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+Write k6 scripts in `./k6/` (e.g. `smoke.k6.js`) or let the runner auto-generate them from endpoint configs.
+
+```bash
+npx zosma-qa run
+```
+
+See the full guide: [Getting Started with Load Testing](docs/GETTING_STARTED_LOAD_TESTING.md)
 
 ---
 
@@ -281,6 +304,7 @@ zosma-qa/
 │   ├── core/          @zosmaai/zosma-qa-core        — types, config, plugin interface
 │   ├── playwright/    @zosmaai/zosma-qa-playwright   — Playwright runner + base config
 │   ├── appium/        @zosmaai/zosma-qa-appium       — Appium mobile runner + test helpers
+│   ├── k6/            @zosmaai/zosma-qa-k6           — k6 load testing runner
 │   ├── cli/           @zosmaai/zosma-qa-cli          — interactive CLI
 │   └── zosma-qa/      zosma-qa                       — CLI entry point wrapper
 ├── templates/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,6 +10,7 @@ zosma-qa/
 │   ├── core/          — plugin interface, config system, test discovery
 │   ├── playwright/    — Playwright runner and base config (web testing)
 │   ├── appium/        — Appium runner, test helpers, device management (mobile testing)
+│   ├── k6/            — k6 load testing runner, script discovery, templates
 │   ├── cli/           — interactive CLI (`npx zosma-qa`)
 │   └── zosma-qa/      — CLI entry point wrapper
 ├── templates/         — scaffold content for `npx zosma-qa init`
@@ -32,6 +33,10 @@ zosma-qa/
 @zosmaai/zosma-qa-appium
   └── @zosmaai/zosma-qa-core
   (peer: appium >=2.0.0)
+
+@zosmaai/zosma-qa-k6
+  └── @zosmaai/zosma-qa-core
+  (peer: k6 CLI binary)
 
 zosma-qa (entry point wrapper)
   └── @zosmaai/zosma-qa-cli
@@ -125,6 +130,30 @@ video: retain-on-failure
 
 ---
 
+## packages/k6
+
+**Purpose:** k6 load testing runner plugin. Wraps the k6 CLI with auto-discovery, script generation, and result parsing.
+
+**Key modules:**
+
+| Module | Description |
+|---|---|
+| `config.ts` | `defineK6Config()` and `loadK6Config()` — config system with sensible defaults |
+| `discovery.ts` | `findK6Scripts()` — recursive `*.k6.js` file discovery |
+| `executor.ts` | `executeK6()` — spawns k6 binary, captures stdout/stderr, reads JSON summary |
+| `parser.ts` | `parseK6Summary()` and `toTestResults()` — extracts structured metrics from k6 output |
+| `runner.ts` | `K6Runner` — implements `ZosmaPlugin`, orchestrates the full pipeline |
+| `templates/` | Script generators for load, stress, spike, and soak test profiles |
+
+**Design decisions:**
+- k6 binary is a peer dependency — users install their own version
+- Each `*.k6.js` script runs as an independent k6 execution
+- Results are normalized to `TestResult[]` for unified reporting
+- When no scripts exist but `endpoints` are configured, scripts are auto-generated from templates
+- Default thresholds: p(95)<500ms response time, <1% error rate
+
+---
+
 ## packages/cli
 
 **Purpose:** Developer-facing UX layer. All commands delegate to underlying tools — the CLI adds prompts, colour, and discoverability, not functionality.
@@ -186,7 +215,10 @@ The `init` command scaffolds this structure and optionally runs `playwright init
 - `*.appium.ts`, `*.appium.js`
 - `*.appium.py`
 
-Ignored directories: `node_modules`, `dist`, `.git`, `.playwright`, `playwright-report`, `test-results`.
+`@zosmaai/zosma-qa-k6`'s `findK6Scripts()` discovers load test scripts matching:
+- `*.k6.js`
+
+Ignored directories: `node_modules`, `dist`, `.git`, `.playwright`, `playwright-report`, `test-results`, `k6-results`.
 
 ---
 
@@ -198,16 +230,16 @@ Ignored directories: `node_modules`, `dist`, `.git`, `.playwright`, `playwright-
 4. Add the runner name to `zosma.config.ts`'s `plugins` array
 5. The CLI's `run` command will pick it up
 
-See `packages/appium/` for a complete reference implementation. Here's a minimal skeleton:
+See `packages/appium/` or `packages/k6/` for complete reference implementations. Here's a minimal skeleton:
 
 ```typescript
 import type { ZosmaPlugin, RunnerConfig, TestResult } from '@zosmaai/zosma-qa-core';
 
-export class K6Runner implements ZosmaPlugin {
-  readonly name = 'k6';
+export class MyRunner implements ZosmaPlugin {
+  readonly name = 'my-runner';
 
   async run(config: RunnerConfig): Promise<TestResult[]> {
-    // spawn k6 run with config
+    // spawn your runner and return normalized results
   }
 }
 ```

--- a/docs/GETTING_STARTED_LOAD_TESTING.md
+++ b/docs/GETTING_STARTED_LOAD_TESTING.md
@@ -1,94 +1,142 @@
-# Getting Started with Load Testing (k6 / Artillery)
+# Getting Started with Load Testing
 
-> **Status: Planned** — Load testing support is on the zosma-qa roadmap but not yet implemented.
+## k6
 
----
+zosma-qa supports load and performance testing via [k6](https://k6.io/) through the `@zosmaai/zosma-qa-k6` package.
 
-## What's Coming
+### Prerequisites
 
-zosma-qa will support load and performance testing through two popular tools:
+- [k6](https://grafana.com/docs/k6/latest/set-up/install-k6/) installed on your machine
+- A zosma-qa project (or run `npx zosma-qa init`)
 
-| Runner | Package | Use Case |
-|---|---|---|
-| **k6** | `@zosmaai/zosma-qa-k6` | Developer-centric load testing with JavaScript |
-| **Artillery** | `@zosmaai/zosma-qa-artillery` | YAML-first load testing with rich scenarios |
+### Installation
 
-Both will follow the same plugin pattern as the Playwright and Appium runners — implement `ZosmaPlugin`, configure in `zosma.config.ts`, run with `npx zosma-qa run`.
+```bash
+npm install -D @zosmaai/zosma-qa-k6
+```
 
----
+### Configuration
 
-## Planned Features
-
-### k6 Integration
-
-- Write load tests in JavaScript/TypeScript
-- Configure via `zosma.config.ts` with `plugins: ['k6']`
-- Run with `npx zosma-qa run` (dispatches to `k6 run`)
-- Results aggregated into the unified report dashboard
+Add `k6` to your plugins in `zosma.config.ts`:
 
 ```typescript
-// Example: future k6 test
-// tests/load/homepage.k6.ts
+// zosma.config.ts
+import { defineConfig } from '@zosmaai/zosma-qa-core';
+
+export default defineConfig({
+  plugins: ['k6'],
+  testDir: './k6',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+Optionally create a `k6.config.ts` for k6-specific settings:
+
+```typescript
+// k6.config.ts
+import { defineK6Config } from '@zosmaai/zosma-qa-k6';
+
+export default defineK6Config({
+  baseURL: 'http://localhost:3000',
+  vus: 50,
+  duration: '2m',
+  testType: 'stress',
+  thresholds: [
+    { metric: 'http_req_duration', condition: 'p(95)<500' },
+    { metric: 'http_req_failed', condition: 'rate<0.01' },
+  ],
+});
+```
+
+If you skip `k6.config.ts`, sensible defaults are applied (10 VUs, 30s duration, p95<500ms threshold).
+
+### Writing tests
+
+Create k6 scripts in your `testDir` with the `.k6.js` extension:
+
+```javascript
+// k6/smoke.k6.js
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 
 export const options = {
-  vus: 50,
+  vus: 10,
   duration: '30s',
 };
 
 export default function () {
-  const res = http.get('https://www.myapp.com');
+  const res = http.get('http://localhost:3000/api/health');
   check(res, { 'status is 200': (r) => r.status === 200 });
   sleep(1);
 }
 ```
 
-### Artillery Integration
+The runner auto-discovers all `*.k6.js` files in `testDir`.
 
-- YAML-based test scenarios
-- Configure via `zosma.config.ts` with `plugins: ['artillery']`
-- Run with `npx zosma-qa run` (dispatches to `artillery run`)
-- Support for HTTP, WebSocket, and Socket.IO protocols
+### Auto-generated scripts
 
-```yaml
-# Example: future Artillery test
-# tests/load/homepage.artillery.yml
-config:
-  target: "https://www.myapp.com"
-  phases:
-    - duration: 30
-      arrivalRate: 10
-scenarios:
-  - flow:
-      - get:
-          url: "/"
-          expect:
-            - statusCode: 200
+If no scripts exist but you have `endpoints` configured in `k6.config.ts`, the runner generates scripts automatically:
+
+```typescript
+defineK6Config({
+  baseURL: 'http://localhost:3000',
+  testType: 'load',
+  endpoints: [
+    { method: 'GET', path: '/api/users' },
+    { method: 'POST', path: '/api/orders', body: { item: 'widget' } },
+  ],
+});
+```
+
+### Test types
+
+| Type | Description |
+|---|---|
+| `load` | Constant VU load for a fixed duration (default) |
+| `stress` | Gradual ramp-up to find the breaking point |
+| `spike` | Sudden burst of traffic |
+| `soak` | Long-running stability test |
+
+Custom ramping stages override the test type preset:
+
+```typescript
+defineK6Config({
+  stages: [
+    { duration: '1m', target: 20 },
+    { duration: '3m', target: 20 },
+    { duration: '1m', target: 0 },
+  ],
+});
+```
+
+### Running
+
+```bash
+npx zosma-qa run
+```
+
+Results are saved to `./k6-results/` as JSON summaries. Failed thresholds cause a non-zero exit code.
+
+### Multi-plugin
+
+k6 works alongside other runners. For example, run E2E tests and load tests in sequence:
+
+```typescript
+export default defineConfig({
+  plugins: ['playwright', 'k6'],
+});
 ```
 
 ---
 
-## Roadmap
+## Artillery — Planned
 
-Load testing is part of **Phase 2** in the [zosma-qa Vision](VISION.md). The implementation order:
-
-1. k6 plugin (JavaScript-native, aligns with TypeScript ecosystem)
-2. Artillery plugin (YAML-first, broader protocol support)
-3. Unified reporting (load metrics alongside E2E and mobile test results)
+Artillery support is on the roadmap. See [Vision & Roadmap](VISION.md) for details.
 
 ---
 
-## Want to Contribute?
+## Reference
 
-If you're interested in building the k6 or Artillery plugin, see:
-
-- [Architecture](ARCHITECTURE.md) — how plugins work
-- [CONTRIBUTING.md](../CONTRIBUTING.md) — development setup and guidelines
-- The existing [`@zosmaai/zosma-qa-appium`](../packages/appium/) package as a reference for building a new runner plugin
-
----
-
-## Stay Updated
-
-Watch the [zosma-qa repository](https://github.com/zosmaai/zosma-qa) for updates on load testing support.
+- [k6 documentation](https://grafana.com/docs/k6/latest/)
+- [`@zosmaai/zosma-qa-k6` README](../packages/k6/README.md)
+- [Architecture](ARCHITECTURE.md)

--- a/packages/cli/src/commands/k6-agents.ts
+++ b/packages/cli/src/commands/k6-agents.ts
@@ -1,0 +1,292 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { select } from '@inquirer/prompts';
+import type { AgentLoop } from '@zosmaai/zosma-qa-core';
+import chalk from 'chalk';
+
+/**
+ * `zosma-qa k6 agents init` — generate AI agent prompt files for k6 load testing.
+ */
+export async function initK6Agents(loopOverride?: AgentLoop): Promise<void> {
+  let loop: AgentLoop;
+
+  if (loopOverride) {
+    loop = loopOverride;
+  } else {
+    console.log('');
+    console.log(chalk.bold.cyan('  zosma-qa k6 agents') + chalk.dim(' — k6 AI agent setup'));
+    console.log('');
+    console.log(
+      chalk.dim(
+        '  This generates agent definitions that let your AI tool act as a\n' +
+          '  k6 load test planner, generator, healer, and analyzer.\n',
+      ),
+    );
+
+    loop = await select<AgentLoop>({
+      message: 'Which AI coding tool are you using?',
+      choices: [
+        {
+          name: 'OpenCode  (default)',
+          value: 'opencode',
+          description: 'opencode.ai — the AI coding agent',
+        },
+        {
+          name: 'Claude Code',
+          value: 'claude',
+          description: "Anthropic's Claude Code CLI (claude.ai/code)",
+        },
+        {
+          name: 'VS Code  (Copilot)',
+          value: 'vscode',
+          description: 'GitHub Copilot agent mode inside VS Code',
+        },
+      ],
+      default: 'opencode',
+    });
+  }
+
+  const cwd = process.cwd();
+  const promptsDir = getPromptsDir(cwd, loop);
+  fs.mkdirSync(promptsDir, { recursive: true });
+
+  const agents = [
+    { filename: 'k6-load-test-planner.md', content: PLANNER_PROMPT },
+    { filename: 'k6-load-test-generator.md', content: GENERATOR_PROMPT },
+    { filename: 'k6-load-test-healer.md', content: HEALER_PROMPT },
+    { filename: 'k6-load-test-analyzer.md', content: ANALYZER_PROMPT },
+  ];
+
+  for (const agent of agents) {
+    const filePath = path.join(promptsDir, agent.filename);
+    if (!fs.existsSync(filePath)) {
+      fs.writeFileSync(filePath, agent.content, 'utf8');
+      console.log(chalk.green(`  Created  ${path.relative(cwd, filePath)}`));
+    } else {
+      console.log(chalk.dim(`  Skipped  ${path.relative(cwd, filePath)}  (already exists)`));
+    }
+  }
+
+  console.log('');
+  console.log(chalk.bold.green('  Agent definitions generated!'));
+  console.log('');
+  console.log(chalk.dim('  Four agents are now available:\n'));
+  console.log(`  ${chalk.bold('📊 planner')}    explores your API and writes a load test plan`);
+  console.log(`  ${chalk.bold('📊 generator')}  turns the plan into k6 test scripts`);
+  console.log(`  ${chalk.bold('📊 healer')}     runs failing k6 tests and repairs them`);
+  console.log(`  ${chalk.bold('📊 analyzer')}   runs tests and analyzes performance results`);
+  console.log('');
+  console.log(
+    chalk.dim(
+      '  Prompt your AI tool:\n' +
+        `    "${chalk.white('Use the k6-load-test-planner agent to plan load tests for my API')}"\n`,
+    ),
+  );
+}
+
+function getPromptsDir(cwd: string, loop: AgentLoop): string {
+  switch (loop) {
+    case 'opencode':
+      return path.join(cwd, '.opencode', 'prompts');
+    case 'claude':
+      return path.join(cwd, '.github', 'agents');
+    case 'vscode':
+      return path.join(cwd, '.github', 'agents');
+    default:
+      return path.join(cwd, '.github', 'agents');
+  }
+}
+
+const PLANNER_PROMPT = `---
+name: k6-load-test-planner
+description: Explores the target API and creates a load test plan
+---
+
+# k6 Load Test Planner
+
+You are an expert performance engineer. Your job is to explore the target API and create a comprehensive load test plan.
+
+## Workflow
+
+1. **Discover endpoints** — Look for:
+   - OpenAPI/Swagger specs (e.g. \`openapi.yaml\`, \`swagger.json\`)
+   - HAR files in the project
+   - Endpoint definitions in \`k6.config.ts\`
+   - Route definitions in the application source code
+   - Existing API documentation
+
+2. **Analyze each endpoint** — For each discovered endpoint, note:
+   - HTTP method and path
+   - Required headers (auth tokens, content types)
+   - Request body schema (for POST/PUT/PATCH)
+   - Expected response codes
+   - Dependencies between endpoints (e.g. create before read)
+
+3. **Design load profiles** — Recommend which test types to use:
+   - **load** — constant VUs for steady-state testing
+   - **stress** — ramping VUs to find breaking points
+   - **spike** — sudden traffic bursts
+   - **soak** — extended duration for memory leak detection
+
+4. **Define thresholds** — Set performance budgets:
+   - p95 response time targets per endpoint
+   - Acceptable error rates
+   - Throughput minimums
+
+5. **Write the plan** — Save a Markdown test plan to \`specs/\`:
+   - \`specs/k6-load-test-plan.md\`
+   - Include: endpoint inventory, test scenarios, thresholds, execution order
+   - Note any prerequisites (auth setup, test data, environment)
+
+## Rules
+- Focus on realistic traffic patterns, not synthetic maximums
+- Consider endpoint dependencies (auth before protected routes)
+- Plan for both happy path and error scenarios
+- Save plans to the existing \`specs/\` directory
+`;
+
+const GENERATOR_PROMPT = `---
+name: k6-load-test-generator
+description: Generates k6 test scripts from a load test plan
+---
+
+# k6 Load Test Generator
+
+You are an expert k6 script writer. Your job is to read test plans from \`specs/\` and generate working k6 scripts.
+
+## Workflow
+
+1. **Read the test plan** from \`specs/k6-load-test-plan.md\` (or other plan files in \`specs/\`)
+
+2. **Generate k6 scripts** in the \`k6/\` directory:
+   - Name files descriptively: \`api-health.k6.js\`, \`user-flow.k6.js\`, etc.
+   - Always include \`handleSummary\` export for JSON output collection
+   - Import \`textSummary\` from k6 jslib
+   - Use \`check()\` assertions for every response
+   - Add \`sleep(1)\` between iterations
+
+3. **Validate each script** with a smoke run:
+   \`\`\`bash
+   k6 run --vus 1 --duration 5s <script>
+   \`\`\`
+   - If the smoke run fails, diagnose and fix the script
+   - Common issues: wrong auth headers, incorrect URLs, missing env vars
+
+4. **Update k6.config.ts** if needed — add endpoint definitions
+
+## Script Template
+
+Every generated script MUST include:
+
+\`\`\`javascript
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+
+export const options = { /* thresholds, vus/stages */ };
+
+export default function () { /* test logic */ }
+
+export function handleSummary(data) {
+  const outputPath = __ENV.SUMMARY_OUTPUT || 'summary.json';
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+    [outputPath]: JSON.stringify(data, null, 2),
+  };
+}
+\`\`\`
+
+## Rules
+- Scripts must be valid k6 JavaScript (no TypeScript — k6 doesn't support it)
+- Always smoke-test generated scripts before marking them as done
+- Use \`__ENV.BASE_URL\` for base URL to allow overriding at runtime
+- Handle authentication in a setup() function when needed
+`;
+
+const HEALER_PROMPT = `---
+name: k6-load-test-healer
+description: Runs failing k6 tests and fixes them
+---
+
+# k6 Load Test Healer
+
+You are an expert at diagnosing and fixing k6 load test failures. Your job is to run failing k6 scripts, diagnose issues, and fix them.
+
+## Workflow
+
+1. **Run the tests**:
+   \`\`\`bash
+   npx zosma-qa k6 run
+   \`\`\`
+
+2. **Diagnose failures** from k6 output. Common issues:
+   - \`connection refused\` — target server not running or wrong URL
+   - \`4xx responses\` — missing auth headers, wrong request body
+   - \`5xx responses\` — server-side errors, report but don't fix
+   - \`threshold violations\` — adjust thresholds or investigate slow endpoints
+   - \`DNS resolution failed\` — wrong hostname
+   - \`request timeout\` — increase timeout or investigate server
+
+3. **Fix the scripts**:
+   - Update URLs, headers, or body payloads as needed
+   - Fix authentication flows
+   - Correct content-type headers
+   - Adjust thresholds if they were unrealistic
+
+4. **Re-run and verify**:
+   \`\`\`bash
+   npx zosma-qa k6 run
+   \`\`\`
+
+5. **Report unfixable issues** — If an issue is server-side (5xx, actual slow performance), add a comment in the script explaining the issue rather than masking it
+
+## Rules
+- Never lower thresholds just to make tests pass — only adjust if they were unrealistic
+- Always re-run after fixing to verify the fix works
+- If the target server is down, report it clearly rather than retrying forever
+- Keep the \`handleSummary\` export intact in all scripts
+`;
+
+const ANALYZER_PROMPT = `---
+name: k6-load-test-analyzer
+description: Runs k6 tests and analyzes performance results
+---
+
+# k6 Load Test Analyzer
+
+You are an expert performance analyst. Your job is to run k6 load tests, read the results, and provide actionable analysis.
+
+## Workflow
+
+1. **Run the tests**:
+   \`\`\`bash
+   npx zosma-qa k6 run
+   \`\`\`
+
+2. **Read results** from \`k6-results/\` directory (JSON files)
+
+3. **Analyze metrics**:
+   - **Response times**: Look at p50, p95, p99 distribution. High p99 with low p50 suggests tail latency issues
+   - **Error rates**: Any rate above 1% warrants investigation
+   - **Throughput**: Compare requests/second against expected capacity
+   - **Connection times**: High connecting times suggest DNS or TCP issues
+
+4. **Identify bottlenecks**:
+   - Endpoints with p95 > 500ms
+   - Endpoints with error rates > 1%
+   - Threshold violations
+   - Degradation patterns (performance getting worse over time in soak tests)
+
+5. **Write analysis** to \`specs/\` or stdout:
+   - Summary of findings
+   - Per-endpoint performance breakdown
+   - Comparison with previous runs (if available in \`k6-results/\`)
+   - Recommendations: connection pooling, caching, rate limiting, indexing, etc.
+
+## Rules
+- Always run the tests first — don't analyze stale results without mentioning it
+- Be specific about which endpoints need attention
+- Provide actionable recommendations, not just observations
+- Compare against thresholds defined in the scripts
+- If results look good, say so — not every analysis needs to find problems
+`;

--- a/packages/cli/src/commands/k6.ts
+++ b/packages/cli/src/commands/k6.ts
@@ -1,0 +1,174 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { loadConfig } from '@zosmaai/zosma-qa-core';
+import { K6Runner } from '@zosmaai/zosma-qa-k6';
+import chalk from 'chalk';
+
+export interface K6RunOptions {
+  type?: string;
+  vus?: string;
+  duration?: string;
+  script?: string;
+  baseUrl?: string;
+}
+
+/**
+ * `zosma-qa k6 run` — execute k6 load tests.
+ */
+export async function runK6(options: K6RunOptions = {}): Promise<void> {
+  console.log('');
+  console.log(chalk.bold.cyan('  zosma-qa') + chalk.dim('  running k6 load tests'));
+  console.log('');
+
+  const runner = new K6Runner();
+  const cwd = process.cwd();
+  const config = await loadConfig(cwd);
+
+  const results = await runner.run({
+    testDir: config.testDir,
+    baseURL: options.baseUrl ?? config.baseURL,
+    browsers: [],
+    reporters: [],
+    ci: false,
+    extraArgs: buildExtraArgs(options),
+  });
+
+  // Print summary
+  console.log('');
+  const passed = results.filter((r) => r.status === 'passed').length;
+  const failed = results.filter((r) => r.status === 'failed').length;
+  const skipped = results.filter((r) => r.status === 'skipped').length;
+
+  if (failed > 0) {
+    console.log(
+      chalk.bold.red(`  ${failed} failed`) + chalk.dim(`, ${passed} passed, ${skipped} skipped`),
+    );
+    for (const r of results.filter((r) => r.status === 'failed')) {
+      console.log(chalk.red(`    ✗ ${r.name}`) + (r.error ? chalk.dim(` — ${r.error}`) : ''));
+    }
+  } else if (skipped > 0 && passed === 0) {
+    console.log(chalk.yellow(`  ${skipped} skipped`));
+    for (const r of results.filter((r) => r.status === 'skipped')) {
+      console.log(chalk.dim(`    - ${r.name}`) + (r.error ? chalk.dim(` — ${r.error}`) : ''));
+    }
+  } else {
+    console.log(chalk.bold.green(`  ${passed} passed`));
+  }
+  console.log('');
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+function buildExtraArgs(options: K6RunOptions): string[] {
+  const args: string[] = [];
+  if (options.type) args.push('--type', options.type);
+  if (options.vus) args.push('--vus', options.vus);
+  if (options.duration) args.push('--duration', options.duration);
+  if (options.script) args.push('--script', options.script);
+  return args;
+}
+
+/**
+ * `zosma-qa k6 init` — scaffold k6 test structure.
+ */
+export async function initK6(): Promise<void> {
+  const cwd = process.cwd();
+
+  console.log('');
+  console.log(chalk.bold.cyan('  zosma-qa k6 init') + chalk.dim(' — scaffold k6 load tests'));
+  console.log('');
+
+  // Create k6/ directory
+  const k6Dir = path.join(cwd, 'k6');
+  if (!fs.existsSync(k6Dir)) {
+    fs.mkdirSync(k6Dir, { recursive: true });
+  }
+
+  // Create example script
+  const examplePath = path.join(k6Dir, 'example.k6.js');
+  if (!fs.existsSync(examplePath)) {
+    fs.writeFileSync(examplePath, EXAMPLE_SCRIPT, 'utf8');
+    console.log(chalk.green(`  Created  k6/example.k6.js`));
+  } else {
+    console.log(chalk.dim(`  Skipped  k6/example.k6.js  (already exists)`));
+  }
+
+  // Create k6.config.ts
+  const configPath = path.join(cwd, 'k6.config.ts');
+  if (!fs.existsSync(configPath)) {
+    fs.writeFileSync(configPath, K6_CONFIG_TEMPLATE, 'utf8');
+    console.log(chalk.green(`  Created  k6.config.ts`));
+  } else {
+    console.log(chalk.dim(`  Skipped  k6.config.ts  (already exists)`));
+  }
+
+  // Create k6-results/ directory
+  const resultsDir = path.join(cwd, 'k6-results');
+  if (!fs.existsSync(resultsDir)) {
+    fs.mkdirSync(resultsDir, { recursive: true });
+    fs.writeFileSync(path.join(resultsDir, '.gitkeep'), '', 'utf8');
+  }
+
+  console.log('');
+  console.log(`${chalk.bold.green('  Ready!')}  Next steps:\n`);
+  console.log(chalk.dim('  1. Install k6 (if not installed):'));
+  console.log(chalk.cyan('     https://k6.io/docs/get-started/installation/'));
+  console.log('');
+  console.log(chalk.dim('  2. Edit k6.config.ts with your base URL and endpoints'));
+  console.log('');
+  console.log(chalk.dim('  3. Run your load tests:'));
+  console.log(chalk.cyan('     npx zosma-qa k6 run'));
+  console.log('');
+}
+
+const EXAMPLE_SCRIPT = `import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+
+export const options = {
+  vus: 10,
+  duration: '30s',
+  thresholds: {
+    'http_req_duration': ['p(95)<500'],
+    'http_req_failed': ['rate<0.01'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+
+export default function () {
+  const res = http.get(BASE_URL);
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'duration < 500ms': (r) => r.timings.duration < 500,
+  });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  const outputPath = __ENV.SUMMARY_OUTPUT || 'summary.json';
+
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+    [outputPath]: JSON.stringify(data, null, 2),
+  };
+}
+`;
+
+const K6_CONFIG_TEMPLATE = `import { defineK6Config } from '@zosmaai/zosma-qa-k6';
+
+export default defineK6Config({
+  // baseURL: 'http://localhost:3000',
+  testType: 'load',
+  vus: 10,
+  duration: '30s',
+  // endpoints: [
+  //   { method: 'GET', path: '/api/health' },
+  //   { method: 'GET', path: '/api/users' },
+  //   { method: 'POST', path: '/api/users', body: { name: 'test' } },
+  // ],
+});
+`;

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { Browser, TestResult } from '@zosmaai/zosma-qa-core';
 import { loadConfig } from '@zosmaai/zosma-qa-core';
+import { K6Runner } from '@zosmaai/zosma-qa-k6';
 import chalk from 'chalk';
 
 export interface RunOptions {
@@ -16,24 +17,58 @@ export interface RunOptions {
 }
 
 /**
- * `zosma-qa run` — detects the active runner from zosma.config and delegates
- * to the appropriate process:
+ * `zosma-qa run` — detects the active runner(s) from zosma.config and delegates
+ * to the appropriate process(es):
  *   - plugins: ['appium']     → AppiumRunner (WebdriverIO-based)
  *   - plugins: ['pytest']     → `uv run pytest` (if uv.lock present) or `python -m pytest`
  *   - plugins: ['playwright'] → `npx playwright test` (default)
+ *   - plugins: ['k6']         → k6 load tests
+ *
+ * Multiple plugins run sequentially.
  */
 export async function runTests(options: RunOptions = {}): Promise<void> {
   const cwd = process.cwd();
   const config = await loadConfig(cwd);
-  const isAppium = config.plugins.includes('appium');
-  const isPython = config.plugins.includes('pytest');
 
-  if (isAppium) {
-    await runAppium(config.testDir ?? './tests', config.baseURL, config.browsers ?? [], cwd);
-  } else if (isPython) {
-    await runPytest(options, config.testDir ?? './tests', cwd);
-  } else {
-    await runPlaywright(options, cwd);
+  for (const plugin of config.plugins) {
+    if (plugin === 'appium') {
+      await runAppium(config.testDir ?? './tests', config.baseURL, config.browsers ?? [], cwd);
+    } else if (plugin === 'pytest') {
+      await runPytest(options, config.testDir ?? './tests', cwd);
+    } else if (plugin === 'k6') {
+      await runK6Plugin(options, config, cwd);
+    } else {
+      await runPlaywright(options, cwd);
+    }
+  }
+}
+
+async function runK6Plugin(
+  _options: RunOptions,
+  config: { testDir: string; baseURL?: string },
+  _cwd: string,
+): Promise<void> {
+  console.log('');
+  console.log(
+    chalk.bold.cyan('  zosma-qa') + chalk.dim('  running: ') + chalk.white('k6 load tests'),
+  );
+  console.log('');
+
+  const runner = new K6Runner();
+  const results = await runner.run({
+    testDir: config.testDir,
+    baseURL: config.baseURL,
+    browsers: [],
+    reporters: [],
+    ci: false,
+  });
+
+  const failed = results.filter((r) => r.status === 'failed');
+  if (failed.length > 0) {
+    for (const r of failed) {
+      console.log(chalk.red(`  ✗ ${r.name}`) + (r.error ? chalk.dim(` — ${r.error}`) : ''));
+    }
+    process.exit(1);
   }
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
 import { initAgents } from './commands/agents';
 import { runInit } from './commands/init';
+import { initK6, runK6 } from './commands/k6';
+import { initK6Agents } from './commands/k6-agents';
 import { openReport } from './commands/report';
 import { runTests } from './commands/run';
 
@@ -46,6 +48,39 @@ agentsCmd
   .option('--loop <loop>', 'AI loop to use: opencode | claude | vscode')
   .action(async (options) => {
     await initAgents(options.loop);
+  });
+
+// ─── k6 ──────────────────────────────────────────────────────────────────────
+
+const k6Cmd = program.command('k6').description('Manage k6 load tests');
+
+k6Cmd
+  .command('run')
+  .description('Run k6 load tests')
+  .option('--type <type>', 'Test type: load | stress | spike | soak')
+  .option('--vus <n>', 'Number of virtual users')
+  .option('--duration <duration>', 'Test duration (e.g. 30s, 5m)')
+  .option('--script <path>', 'Run a specific k6 script')
+  .option('--base-url <url>', 'Override base URL')
+  .action(async (options) => {
+    await runK6(options);
+  });
+
+k6Cmd
+  .command('init')
+  .description('Scaffold k6 test structure with example script and config')
+  .action(async () => {
+    await initK6();
+  });
+
+const k6AgentsCmd = k6Cmd.command('agents').description('Manage k6 AI agent definitions');
+
+k6AgentsCmd
+  .command('init')
+  .description('Generate k6 AI agent definitions for your AI coding tool')
+  .option('--loop <loop>', 'AI loop to use: opencode | claude | vscode')
+  .action(async (options) => {
+    await initK6Agents(options.loop);
   });
 
 // ─── report ───────────────────────────────────────────────────────────────────

--- a/packages/k6/README.md
+++ b/packages/k6/README.md
@@ -1,0 +1,113 @@
+# @zosmaai/zosma-qa-k6
+
+k6 load testing runner for [zosma-qa](https://github.com/zosmaai/zosma-qa) — the zero-config QA platform.
+
+This package wraps the k6 CLI with auto-discovery, script generation, result parsing, and sensible defaults so you can run load tests with zero boilerplate.
+
+## Installation
+
+```bash
+npm install -D @zosmaai/zosma-qa-k6
+```
+
+k6 must be installed separately — see [k6 installation docs](https://grafana.com/docs/k6/latest/set-up/install-k6/).
+
+## Usage
+
+```typescript
+// zosma.config.ts
+import { defineConfig } from '@zosmaai/zosma-qa-core';
+
+export default defineConfig({
+  plugins: ['k6'],
+  testDir: './k6',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+```typescript
+// k6.config.ts (optional — defaults are applied automatically)
+import { defineK6Config } from '@zosmaai/zosma-qa-k6';
+
+export default defineK6Config({
+  baseURL: 'http://localhost:3000',
+  vus: 50,
+  duration: '2m',
+  testType: 'stress',
+});
+```
+
+```bash
+npx zosma-qa run
+```
+
+## Test types
+
+| Type | Description |
+|---|---|
+| `load` | Constant VU load for a fixed duration (default) |
+| `stress` | Gradual ramp-up to find the breaking point |
+| `spike` | Sudden burst of traffic |
+| `soak` | Long-running stability test |
+
+## Smart defaults
+
+| Setting | Default |
+|---|---|
+| `vus` | `10` |
+| `duration` | `30s` |
+| `testDir` | `./k6` |
+| `testMatch` | `*.k6.js` |
+| `outputDir` | `./k6-results` |
+| `thresholds` | p(95)<500ms, error rate<1% |
+| `timeoutSeconds` | `300` |
+
+## Script discovery
+
+The runner recursively finds all `*.k6.js` files in `testDir` (ignoring `node_modules`, `dist`, `.git`, `k6-results`). Each script is executed as an independent k6 run.
+
+## Script generation
+
+If no scripts exist but `endpoints` are configured, the runner auto-generates k6 scripts from templates:
+
+```typescript
+defineK6Config({
+  baseURL: 'http://localhost:3000',
+  endpoints: [
+    { method: 'GET', path: '/api/users' },
+    { method: 'POST', path: '/api/orders', body: { item: 'widget' } },
+  ],
+});
+```
+
+## All k6 options still work
+
+You can always write raw `.k6.js` scripts with full k6 API access — the runner discovers and executes them as-is:
+
+```javascript
+// k6/checkout.k6.js
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = { vus: 100, duration: '5m' };
+
+export default function () {
+  const res = http.get('https://www.myapp.com/api/checkout');
+  check(res, { 'status is 200': (r) => r.status === 200 });
+  sleep(1);
+}
+```
+
+## Part of zosma-qa
+
+- [`@zosmaai/zosma-qa-core`](https://www.npmjs.com/package/@zosmaai/zosma-qa-core) — shared types and plugin interface
+- [`@zosmaai/zosma-qa-playwright`](https://www.npmjs.com/package/@zosmaai/zosma-qa-playwright) — Playwright web testing runner
+- [`@zosmaai/zosma-qa-appium`](https://www.npmjs.com/package/@zosmaai/zosma-qa-appium) — Appium mobile testing runner
+- [`@zosmaai/zosma-qa-k6`](https://www.npmjs.com/package/@zosmaai/zosma-qa-k6) — this package
+- [`@zosmaai/zosma-qa-cli`](https://www.npmjs.com/package/@zosmaai/zosma-qa-cli) — interactive CLI (`npx zosma-qa`)
+
+Full documentation: [github.com/zosmaai/zosma-qa](https://github.com/zosmaai/zosma-qa)
+
+## License
+
+Apache-2.0

--- a/packages/k6/package.json
+++ b/packages/k6/package.json
@@ -1,34 +1,28 @@
 {
-  "name": "@zosmaai/zosma-qa-cli",
+  "name": "@zosmaai/zosma-qa-k6",
   "version": "0.0.1",
-  "description": "CLI for zosma-qa — zero-config QA platform",
+  "description": "k6 load testing runner plugin for zosma-qa",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/zosmaai/zosma-qa.git",
-    "directory": "packages/cli"
+    "directory": "packages/k6"
   },
   "homepage": "https://github.com/zosmaai/zosma-qa#readme",
   "bugs": {
     "url": "https://github.com/zosmaai/zosma-qa/issues"
   },
   "keywords": [
-    "playwright",
-    "testing",
+    "k6",
+    "load-testing",
+    "performance",
     "qa",
-    "e2e",
-    "cli",
-    "zero-config",
-    "ai-agents"
+    "zero-config"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "bin": {
-    "zosma-qa": "bin/zosma-qa.js"
-  },
   "files": [
-    "dist",
-    "bin"
+    "dist"
   ],
   "scripts": {
     "build": "tsc --project tsconfig.json",
@@ -36,14 +30,7 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@zosmaai/zosma-qa-appium": "workspace:*",
-    "@zosmaai/zosma-qa-core": "workspace:*",
-    "@zosmaai/zosma-qa-k6": "workspace:*",
-    "@zosmaai/zosma-qa-playwright": "workspace:*",
-    "@inquirer/prompts": "^7.0.0",
-    "chalk": "^5.3.0",
-    "commander": "^12.1.0",
-    "ora": "^8.1.1"
+    "@zosmaai/zosma-qa-core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/k6/src/config.ts
+++ b/packages/k6/src/config.ts
@@ -1,0 +1,56 @@
+import type { K6Config } from './types';
+
+const DEFAULTS: K6Config = {
+  testType: 'load',
+  vus: 10,
+  duration: '30s',
+  thresholds: [
+    { metric: 'http_req_duration', condition: 'p(95)<500' },
+    { metric: 'http_req_failed', condition: 'rate<0.01' },
+  ],
+  k6BinaryPath: 'k6',
+  timeoutSeconds: 300,
+  testDir: './k6',
+  testMatch: '*.k6.js',
+  outputDir: './k6-results',
+};
+
+/**
+ * Define k6 configuration with sensible defaults applied.
+ * Use this in your k6.config.ts.
+ *
+ * @example
+ * import { defineK6Config } from '@zosmaai/zosma-qa-k6';
+ * export default defineK6Config({
+ *   baseURL: 'http://localhost:3000',
+ *   vus: 50,
+ *   duration: '2m',
+ * });
+ */
+export function defineK6Config(overrides: Partial<K6Config> = {}): K6Config {
+  return {
+    ...DEFAULTS,
+    ...overrides,
+    thresholds: overrides.thresholds ?? DEFAULTS.thresholds,
+  };
+}
+
+/**
+ * Attempt to load k6.config.ts / k6.config.js from the working directory.
+ * Falls back to defaults if not found.
+ */
+export async function loadK6Config(cwd: string = process.cwd()): Promise<K6Config> {
+  const candidates = [`${cwd}/k6.config.ts`, `${cwd}/k6.config.js`, `${cwd}/k6.config.mjs`];
+
+  for (const file of candidates) {
+    try {
+      const mod = require(file);
+      const config = mod.default ?? mod;
+      return defineK6Config(config);
+    } catch {
+      // file not found or parse error — try next
+    }
+  }
+
+  return defineK6Config();
+}

--- a/packages/k6/src/discovery.ts
+++ b/packages/k6/src/discovery.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const IGNORED_DIRS = new Set(['node_modules', 'dist', '.git', 'k6-results']);
+
+/**
+ * Recursively find k6 test scripts (*.k6.js) in the given directory.
+ */
+export function findK6Scripts(testDir: string, cwd: string = process.cwd()): string[] {
+  const resolvedDir = path.isAbsolute(testDir) ? testDir : path.join(cwd, testDir);
+
+  if (!fs.existsSync(resolvedDir)) {
+    return [];
+  }
+
+  return walk(resolvedDir);
+}
+
+function walk(dir: string): string[] {
+  const results: string[] = [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRS.has(entry.name)) {
+        continue;
+      }
+      results.push(...walk(path.join(dir, entry.name)));
+    } else if (entry.isFile()) {
+      if (entry.name.endsWith('.k6.js')) {
+        results.push(path.join(dir, entry.name));
+      }
+    }
+  }
+
+  return results;
+}

--- a/packages/k6/src/executor.ts
+++ b/packages/k6/src/executor.ts
@@ -1,0 +1,131 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { K6Config, K6ExecutionResult } from './types';
+
+/**
+ * Execute a k6 script and collect the summary JSON output.
+ */
+export async function executeK6(scriptPath: string, config: K6Config): Promise<K6ExecutionResult> {
+  const summaryPath = path.join(
+    os.tmpdir(),
+    `k6-summary-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+  );
+
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    SUMMARY_OUTPUT: summaryPath,
+  };
+
+  try {
+    const { exitCode, output } = await spawnK6(
+      config.k6BinaryPath,
+      scriptPath,
+      env,
+      config.timeoutSeconds,
+    );
+
+    // Read and clean up summary JSON
+    let summary: Record<string, unknown> = {};
+    try {
+      if (fs.existsSync(summaryPath)) {
+        const raw = fs.readFileSync(summaryPath, 'utf8');
+        summary = JSON.parse(raw);
+        fs.unlinkSync(summaryPath);
+      }
+    } catch {
+      // summary parse failed — leave empty
+    }
+
+    let error = '';
+    if (exitCode !== 0 && Object.keys(summary).length === 0) {
+      error = `k6 exited with code ${exitCode}:\n${output.slice(0, 1000)}`;
+    } else if (Object.keys(summary).length === 0 && exitCode === 0) {
+      error = `k6 ran but no summary.json found. k6 output:\n${output.slice(0, 1000)}`;
+    }
+
+    return { exitCode, summary, output, error };
+  } catch (err) {
+    // Clean up temp file on error
+    try {
+      if (fs.existsSync(summaryPath)) fs.unlinkSync(summaryPath);
+    } catch {
+      /* ignore */
+    }
+
+    if (err instanceof K6NotFoundError) {
+      return {
+        exitCode: 1,
+        summary: {},
+        output: '',
+        error: `k6 binary not found at '${config.k6BinaryPath}'. Install k6: https://k6.io/docs/get-started/installation/`,
+      };
+    }
+    if (err instanceof K6TimeoutError) {
+      return {
+        exitCode: 1,
+        summary: {},
+        output: '',
+        error: `k6 timed out after ${config.timeoutSeconds}s`,
+      };
+    }
+    throw err;
+  }
+}
+
+class K6NotFoundError extends Error {}
+class K6TimeoutError extends Error {}
+
+function spawnK6(
+  binary: string,
+  scriptPath: string,
+  env: Record<string, string>,
+  timeoutSeconds: number,
+): Promise<{ exitCode: number; output: string }> {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    let child: ReturnType<typeof spawn>;
+
+    try {
+      child = spawn(binary, ['run', scriptPath], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        cwd: path.dirname(scriptPath),
+        env,
+      });
+    } catch {
+      reject(new K6NotFoundError());
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new K6TimeoutError());
+    }, timeoutSeconds * 1000);
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      output += text;
+      process.stdout.write(text);
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      output += text;
+      process.stderr.write(text);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ exitCode: code ?? 1, output });
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        reject(new K6NotFoundError());
+      } else {
+        reject(err);
+      }
+    });
+  });
+}

--- a/packages/k6/src/index.ts
+++ b/packages/k6/src/index.ts
@@ -1,0 +1,16 @@
+export { defineK6Config, loadK6Config } from './config';
+export { findK6Scripts } from './discovery';
+export { executeK6 } from './executor';
+export { parseK6Summary, toTestResults } from './parser';
+export { K6Runner } from './runner';
+export { generateScript } from './templates/index';
+export type {
+  K6Config,
+  K6Endpoint,
+  K6ExecutionResult,
+  K6Metrics,
+  K6MetricValues,
+  K6Stage,
+  K6TestType,
+  K6Threshold,
+} from './types';

--- a/packages/k6/src/parser.ts
+++ b/packages/k6/src/parser.ts
@@ -1,0 +1,114 @@
+import type { TestResult } from '@zosmaai/zosma-qa-core';
+import type { K6Metrics, K6MetricValues } from './types';
+
+/**
+ * Extract a metric's percentile values from k6 summary data.
+ */
+function extractMetric(metrics: Record<string, unknown>, name: string): K6MetricValues {
+  const metric = metrics[name];
+  if (metric && typeof metric === 'object') {
+    const m = metric as Record<string, unknown>;
+    const values = (m.values ?? m) as Record<string, number>;
+    return {
+      avg: values.avg ?? 0,
+      min: values.min ?? 0,
+      max: values.max ?? 0,
+      med: values.med ?? 0,
+      p90: values['p(90)'] ?? 0,
+      p95: values['p(95)'] ?? 0,
+      p99: values['p(99)'] ?? 0,
+    };
+  }
+  return { avg: 0, min: 0, max: 0, med: 0, p90: 0, p95: 0, p99: 0 };
+}
+
+function extractCount(metrics: Record<string, unknown>, name: string, field: string): number {
+  const metric = metrics[name];
+  if (metric && typeof metric === 'object') {
+    const m = metric as Record<string, unknown>;
+    const values = (m.values ?? m) as Record<string, number>;
+    return values[field] ?? 0;
+  }
+  return 0;
+}
+
+/**
+ * Parse raw k6 summary JSON into structured metrics.
+ */
+export function parseK6Summary(raw: Record<string, unknown>): K6Metrics {
+  const metrics = (raw.metrics ?? raw) as Record<string, unknown>;
+
+  // Request failure rate
+  let errorRate = 0;
+  const failed = metrics.http_req_failed;
+  if (failed && typeof failed === 'object') {
+    const f = failed as Record<string, unknown>;
+    const values = (f.values ?? f) as Record<string, number>;
+    errorRate = values.rate ?? values.value ?? 0;
+  }
+
+  // Check threshold results
+  let thresholdsPassed = true;
+  const thresholdDetails: Record<string, boolean> = {};
+  for (const [metricName, metricData] of Object.entries(metrics)) {
+    if (metricData && typeof metricData === 'object') {
+      const m = metricData as Record<string, unknown>;
+      if (m.thresholds && typeof m.thresholds === 'object') {
+        for (const [thresholdName, thresholdOk] of Object.entries(
+          m.thresholds as Record<string, unknown>,
+        )) {
+          const ok = Boolean(thresholdOk);
+          thresholdDetails[`${metricName}.${thresholdName}`] = ok;
+          if (!ok) thresholdsPassed = false;
+        }
+      }
+    }
+  }
+
+  return {
+    duration: extractMetric(metrics, 'http_req_duration'),
+    waiting: extractMetric(metrics, 'http_req_waiting'),
+    connecting: extractMetric(metrics, 'http_req_connecting'),
+    errorRate,
+    totalRequests: extractCount(metrics, 'http_reqs', 'count'),
+    requestsPerSecond: extractCount(metrics, 'http_reqs', 'rate'),
+    bytesReceived: extractCount(metrics, 'data_received', 'count'),
+    bytesSent: extractCount(metrics, 'data_sent', 'count'),
+    maxVus: extractCount(metrics, 'vus', 'max') || extractCount(metrics, 'vus', 'value'),
+    totalIterations: extractCount(metrics, 'iterations', 'count'),
+    thresholdsPassed,
+    thresholdDetails,
+  };
+}
+
+/**
+ * Convert k6 metrics into normalized TestResult array.
+ */
+export function toTestResults(
+  scriptName: string,
+  metrics: K6Metrics,
+  exitCode: number,
+  wallClockMs: number,
+): TestResult[] {
+  const passed = metrics.thresholdsPassed && exitCode === 0;
+
+  const result: TestResult = {
+    name: scriptName,
+    status: passed ? 'passed' : 'failed',
+    duration: wallClockMs,
+  };
+
+  if (!passed) {
+    const failedThresholds = Object.entries(metrics.thresholdDetails)
+      .filter(([, ok]) => !ok)
+      .map(([name]) => name);
+
+    if (failedThresholds.length > 0) {
+      result.error = `Thresholds failed: ${failedThresholds.join(', ')}`;
+    } else if (exitCode !== 0) {
+      result.error = `k6 exited with code ${exitCode}`;
+    }
+  }
+
+  return [result];
+}

--- a/packages/k6/src/runner.ts
+++ b/packages/k6/src/runner.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RunnerConfig, TestResult, ZosmaPlugin } from '@zosmaai/zosma-qa-core';
+import { loadK6Config } from './config';
+import { findK6Scripts } from './discovery';
+import { executeK6 } from './executor';
+import { parseK6Summary, toTestResults } from './parser';
+import { generateScript } from './templates/index';
+
+/**
+ * k6 load testing plugin.
+ * Delegates to the k6 CLI under the hood — a clean wrapper with no AI/LLM logic.
+ */
+export class K6Runner implements ZosmaPlugin {
+  readonly name = 'k6';
+
+  async run(config: RunnerConfig): Promise<TestResult[]> {
+    const cwd = process.cwd();
+    const k6Config = await loadK6Config(cwd);
+
+    // Apply CLI overrides
+    if (config.baseURL) {
+      k6Config.baseURL = config.baseURL;
+    }
+
+    // Discover existing k6 scripts
+    let scripts = findK6Scripts(k6Config.testDir, cwd);
+
+    // If no scripts found but endpoints configured, generate from template
+    if (scripts.length === 0 && k6Config.endpoints && k6Config.endpoints.length > 0) {
+      const testDir = path.isAbsolute(k6Config.testDir)
+        ? k6Config.testDir
+        : path.join(cwd, k6Config.testDir);
+
+      if (!fs.existsSync(testDir)) {
+        fs.mkdirSync(testDir, { recursive: true });
+      }
+
+      const scriptContent = generateScript(k6Config);
+      const generatedPath = path.join(testDir, `generated-${k6Config.testType}.k6.js`);
+      fs.writeFileSync(generatedPath, scriptContent, 'utf8');
+      scripts = [generatedPath];
+    }
+
+    if (scripts.length === 0) {
+      return [
+        {
+          name: 'k6 suite',
+          status: 'skipped',
+          duration: 0,
+          error: `No k6 scripts found in ${k6Config.testDir}. Run 'npx zosma-qa k6 init' to get started.`,
+        },
+      ];
+    }
+
+    // Ensure output directory exists
+    const outputDir = path.isAbsolute(k6Config.outputDir)
+      ? k6Config.outputDir
+      : path.join(cwd, k6Config.outputDir);
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    // Execute each script and collect results
+    const allResults: TestResult[] = [];
+
+    for (const scriptPath of scripts) {
+      const scriptName = path.relative(cwd, scriptPath);
+      const startTime = Date.now();
+
+      const execResult = await executeK6(scriptPath, k6Config);
+      const wallClockMs = Date.now() - startTime;
+
+      if (execResult.error && Object.keys(execResult.summary).length === 0) {
+        allResults.push({
+          name: scriptName,
+          status: 'failed',
+          duration: wallClockMs,
+          error: execResult.error,
+        });
+        continue;
+      }
+
+      const metrics = parseK6Summary(execResult.summary);
+      const results = toTestResults(scriptName, metrics, execResult.exitCode, wallClockMs);
+      allResults.push(...results);
+
+      // Save raw results to output directory
+      const resultFileName = `${path.basename(scriptPath, '.k6.js')}.json`;
+      const resultPath = path.join(outputDir, resultFileName);
+      fs.writeFileSync(resultPath, JSON.stringify(execResult.summary, null, 2), 'utf8');
+    }
+
+    return allResults;
+  }
+
+  async report(_results: TestResult[]): Promise<void> {
+    const cwd = process.cwd();
+    const k6Config = await loadK6Config(cwd);
+    const outputDir = path.isAbsolute(k6Config.outputDir)
+      ? k6Config.outputDir
+      : path.join(cwd, k6Config.outputDir);
+
+    if (!fs.existsSync(outputDir)) {
+      console.log('No k6 results found. Run tests first with: npx zosma-qa k6 run');
+      return;
+    }
+
+    const files = fs.readdirSync(outputDir).filter((f) => f.endsWith('.json'));
+    if (files.length === 0) {
+      console.log('No k6 result files found in', outputDir);
+      return;
+    }
+
+    for (const file of files) {
+      const raw = fs.readFileSync(path.join(outputDir, file), 'utf8');
+      const summary = JSON.parse(raw);
+      const metrics = parseK6Summary(summary);
+
+      console.log(`\n--- ${file} ---`);
+      console.log(
+        `  Duration  p95: ${metrics.duration.p95.toFixed(2)}ms  avg: ${metrics.duration.avg.toFixed(2)}ms`,
+      );
+      console.log(
+        `  Requests: ${metrics.totalRequests} total, ${metrics.requestsPerSecond.toFixed(2)} req/s`,
+      );
+      console.log(`  Error rate: ${(metrics.errorRate * 100).toFixed(2)}%`);
+      console.log(`  VUs: ${metrics.maxVus} max`);
+      console.log(`  Thresholds: ${metrics.thresholdsPassed ? 'PASSED' : 'FAILED'}`);
+
+      if (!metrics.thresholdsPassed) {
+        const failed = Object.entries(metrics.thresholdDetails)
+          .filter(([, ok]) => !ok)
+          .map(([name]) => name);
+        console.log(`  Failed: ${failed.join(', ')}`);
+      }
+    }
+  }
+}

--- a/packages/k6/src/templates/index.ts
+++ b/packages/k6/src/templates/index.ts
@@ -1,0 +1,102 @@
+import type { K6Config, K6Endpoint, K6Stage, K6Threshold } from '../types';
+import { generateLoadScript } from './load';
+import { generateSoakScript } from './soak';
+import { generateSpikeScript } from './spike';
+import { generateStressScript } from './stress';
+
+/**
+ * Generate a k6 test script based on the config's testType.
+ */
+export function generateScript(config: K6Config): string {
+  switch (config.testType) {
+    case 'stress':
+      return generateStressScript(config);
+    case 'spike':
+      return generateSpikeScript(config);
+    case 'soak':
+      return generateSoakScript(config);
+    default:
+      return generateLoadScript(config);
+  }
+}
+
+/**
+ * Format thresholds for k6 options block.
+ */
+export function generateThresholds(thresholds: K6Threshold[]): string {
+  return thresholds.map((t) => `    '${t.metric}': ['${t.condition}'],`).join('\n');
+}
+
+/**
+ * Format stages for k6 options block.
+ */
+export function generateStages(stages: K6Stage[]): string {
+  return stages.map((s) => `    { duration: '${s.duration}', target: ${s.target} },`).join('\n');
+}
+
+/**
+ * Generate the default function body with endpoint requests and checks.
+ */
+export function generateEndpointBlock(endpoints: K6Endpoint[], _baseURL: string): string {
+  if (endpoints.length === 0) {
+    return `  const res = http.get(BASE_URL);\n  check(res, {\n    'status is 200': (r) => r.status === 200,\n  });\n`;
+  }
+
+  return endpoints
+    .map((ep) => {
+      const method = ep.method.toUpperCase();
+      const methodLower = ep.method.toLowerCase();
+      const lines: string[] = [];
+
+      lines.push(`  // --- ${method} ${ep.path} ---`);
+      lines.push(`  {`);
+      lines.push(`    const url = \`\${BASE_URL}${ep.path}\`;`);
+
+      if (ep.headers && Object.keys(ep.headers).length > 0) {
+        const headerEntries = Object.entries(ep.headers)
+          .map(([k, v]) => `      '${k}': '${v}',`)
+          .join('\n');
+        lines.push(`    const params = {\n      headers: {\n${headerEntries}\n      },\n    };`);
+      } else {
+        lines.push(`    const params = {};`);
+      }
+
+      if (['POST', 'PUT', 'PATCH'].includes(method)) {
+        if (ep.body) {
+          lines.push(`    const payload = JSON.stringify(${JSON.stringify(ep.body)});`);
+          lines.push(`    if (!params.headers) params.headers = {};`);
+          lines.push(`    params.headers['Content-Type'] = 'application/json';`);
+          lines.push(`    const res = http.${methodLower}(url, payload, params);`);
+        } else {
+          lines.push(`    const res = http.${methodLower}(url, null, params);`);
+        }
+      } else if (method === 'DELETE') {
+        lines.push(`    const res = http.del(url, null, params);`);
+      } else {
+        lines.push(`    const res = http.${methodLower}(url, params);`);
+      }
+
+      lines.push(`    check(res, {`);
+      lines.push(`      '${method} ${ep.path} status 200': (r) => r.status === 200,`);
+      lines.push(`      '${method} ${ep.path} duration < 500ms': (r) => r.timings.duration < 500,`);
+      lines.push(`    });`);
+      lines.push(`  }`);
+
+      return lines.join('\n');
+    })
+    .join('\n\n');
+}
+
+/**
+ * Generate the handleSummary export for collecting JSON results.
+ */
+export function generateHandleSummary(): string {
+  return `export function handleSummary(data) {
+  const outputPath = __ENV.SUMMARY_OUTPUT || 'summary.json';
+
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+    [outputPath]: JSON.stringify(data, null, 2),
+  };
+}`;
+}

--- a/packages/k6/src/templates/load.ts
+++ b/packages/k6/src/templates/load.ts
@@ -1,0 +1,32 @@
+import type { K6Config } from '../types';
+import { generateEndpointBlock, generateHandleSummary, generateThresholds } from './index';
+
+/**
+ * Generate a constant-VU load test script.
+ */
+export function generateLoadScript(config: K6Config): string {
+  const thresholds = generateThresholds(config.thresholds);
+  const endpoints = generateEndpointBlock(config.endpoints ?? [], config.baseURL ?? '');
+
+  return `import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+
+export const options = {
+  vus: ${config.vus},
+  duration: '${config.duration}',
+  thresholds: {
+${thresholds}
+  },
+};
+
+const BASE_URL = '${config.baseURL ?? ''}';
+
+export default function () {
+${endpoints}
+  sleep(1);
+}
+
+${generateHandleSummary()}
+`;
+}

--- a/packages/k6/src/templates/soak.ts
+++ b/packages/k6/src/templates/soak.ts
@@ -1,0 +1,48 @@
+import type { K6Config } from '../types';
+import {
+  generateEndpointBlock,
+  generateHandleSummary,
+  generateStages,
+  generateThresholds,
+} from './index';
+
+/**
+ * Generate a soak/endurance test script.
+ * 5m ramp up, hold for duration (default 30m), 5m ramp down.
+ */
+export function generateSoakScript(config: K6Config): string {
+  const thresholds = generateThresholds(config.thresholds);
+  const endpoints = generateEndpointBlock(config.endpoints ?? [], config.baseURL ?? '');
+  const holdDuration = config.duration || '30m';
+
+  const stages = config.stages
+    ? generateStages(config.stages)
+    : generateStages([
+        { duration: '5m', target: config.vus },
+        { duration: holdDuration, target: config.vus },
+        { duration: '5m', target: 0 },
+      ]);
+
+  return `import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+
+export const options = {
+  stages: [
+${stages}
+  ],
+  thresholds: {
+${thresholds}
+  },
+};
+
+const BASE_URL = '${config.baseURL ?? ''}';
+
+export default function () {
+${endpoints}
+  sleep(1);
+}
+
+${generateHandleSummary()}
+`;
+}

--- a/packages/k6/src/templates/spike.ts
+++ b/packages/k6/src/templates/spike.ts
@@ -1,0 +1,49 @@
+import type { K6Config } from '../types';
+import {
+  generateEndpointBlock,
+  generateHandleSummary,
+  generateStages,
+  generateThresholds,
+} from './index';
+
+/**
+ * Generate a spike test script.
+ * Warm up at 10 VUs, spike to target, hold 30s, recover.
+ */
+export function generateSpikeScript(config: K6Config): string {
+  const thresholds = generateThresholds(config.thresholds);
+  const endpoints = generateEndpointBlock(config.endpoints ?? [], config.baseURL ?? '');
+
+  const stages = config.stages
+    ? generateStages(config.stages)
+    : generateStages([
+        { duration: '1m', target: 10 },
+        { duration: '10s', target: config.vus },
+        { duration: '30s', target: config.vus },
+        { duration: '10s', target: 10 },
+        { duration: '1m', target: 10 },
+      ]);
+
+  return `import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+
+export const options = {
+  stages: [
+${stages}
+  ],
+  thresholds: {
+${thresholds}
+  },
+};
+
+const BASE_URL = '${config.baseURL ?? ''}';
+
+export default function () {
+${endpoints}
+  sleep(1);
+}
+
+${generateHandleSummary()}
+`;
+}

--- a/packages/k6/src/templates/stress.ts
+++ b/packages/k6/src/templates/stress.ts
@@ -1,0 +1,49 @@
+import type { K6Config } from '../types';
+import {
+  generateEndpointBlock,
+  generateHandleSummary,
+  generateStages,
+  generateThresholds,
+} from './index';
+
+/**
+ * Generate a stress test script with ramping VUs.
+ * Ramps to 50%, holds, ramps to 100%, holds, ramps down.
+ */
+export function generateStressScript(config: K6Config): string {
+  const thresholds = generateThresholds(config.thresholds);
+  const endpoints = generateEndpointBlock(config.endpoints ?? [], config.baseURL ?? '');
+
+  const stages = config.stages
+    ? generateStages(config.stages)
+    : generateStages([
+        { duration: '2m', target: Math.ceil(config.vus * 0.5) },
+        { duration: '2m', target: Math.ceil(config.vus * 0.5) },
+        { duration: '2m', target: config.vus },
+        { duration: '5m', target: config.vus },
+        { duration: '2m', target: 0 },
+      ]);
+
+  return `import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+
+export const options = {
+  stages: [
+${stages}
+  ],
+  thresholds: {
+${thresholds}
+  },
+};
+
+const BASE_URL = '${config.baseURL ?? ''}';
+
+export default function () {
+${endpoints}
+  sleep(1);
+}
+
+${generateHandleSummary()}
+`;
+}

--- a/packages/k6/src/types.ts
+++ b/packages/k6/src/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Supported k6 test types, each with a different load profile.
+ */
+export type K6TestType = 'load' | 'stress' | 'spike' | 'soak';
+
+/**
+ * A single k6 ramping stage.
+ */
+export interface K6Stage {
+  duration: string;
+  target: number;
+}
+
+/**
+ * A k6 threshold definition.
+ */
+export interface K6Threshold {
+  metric: string;
+  condition: string;
+}
+
+/**
+ * An API endpoint to include in generated k6 scripts.
+ */
+export interface K6Endpoint {
+  method: string;
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+/**
+ * Configuration for the k6 plugin (k6.config.ts).
+ */
+export interface K6Config {
+  /** Test profile type. Default: 'load' */
+  testType: K6TestType;
+  /** Number of virtual users. Default: 10 */
+  vus: number;
+  /** Test duration (k6 format, e.g. '30s', '5m'). Default: '30s' */
+  duration: string;
+  /** Custom ramping stages — overrides testType preset when provided */
+  stages?: K6Stage[];
+  /** Performance thresholds. Default: [p(95)<500, rate<0.01] */
+  thresholds: K6Threshold[];
+  /** Base URL for generated scripts */
+  baseURL?: string;
+  /** Path to k6 binary. Default: 'k6' */
+  k6BinaryPath: string;
+  /** Timeout for k6 execution in seconds. Default: 300 */
+  timeoutSeconds: number;
+  /** Directory containing k6 test scripts. Default: './k6' */
+  testDir: string;
+  /** Glob pattern for matching k6 scripts. Default: '*.k6.js' */
+  testMatch: string;
+  /** Endpoints to generate scripts for (when no scripts exist) */
+  endpoints?: K6Endpoint[];
+  /** Directory for k6 result output. Default: './k6-results' */
+  outputDir: string;
+}
+
+/**
+ * Parsed metric values from k6 summary JSON.
+ */
+export interface K6MetricValues {
+  avg: number;
+  min: number;
+  max: number;
+  med: number;
+  p90: number;
+  p95: number;
+  p99: number;
+}
+
+/**
+ * Structured metrics extracted from a k6 run.
+ */
+export interface K6Metrics {
+  duration: K6MetricValues;
+  waiting: K6MetricValues;
+  connecting: K6MetricValues;
+  errorRate: number;
+  totalRequests: number;
+  requestsPerSecond: number;
+  bytesReceived: number;
+  bytesSent: number;
+  maxVus: number;
+  totalIterations: number;
+  thresholdsPassed: boolean;
+  thresholdDetails: Record<string, boolean>;
+}
+
+/**
+ * Raw result from a k6 execution.
+ */
+export interface K6ExecutionResult {
+  exitCode: number;
+  summary: Record<string, unknown>;
+  output: string;
+  error: string;
+}

--- a/packages/k6/tsconfig.json
+++ b/packages/k6/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       '@zosmaai/zosma-qa-core':
         specifier: workspace:*
         version: link:../core
+      '@zosmaai/zosma-qa-k6':
+        specifier: workspace:*
+        version: link:../k6
       '@zosmaai/zosma-qa-playwright':
         specifier: workspace:*
         version: link:../playwright
@@ -106,6 +109,19 @@ importers:
         version: 5.9.3
 
   packages/core:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
+  packages/k6:
+    dependencies:
+      '@zosmaai/zosma-qa-core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^20.0.0


### PR DESCRIPTION
Summary:

Adds @zosmaai/zosma-qa-k6 package with k6 runner, script discovery, templates, and result parser. Resolves merge conflict in run.ts by keeping loop-based dispatch and adding appium as a case alongside pytest, k6, and playwright.

Checklist:
  - pnpm build passes
  - pnpm typecheck passes
  - pnpm lint passes
  - Tests added or updated (if applicable)
  - Documentation updated (if applicable)
