### PR TITLE
ci: add k6 package to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           npm --prefix packages/core       version "$VERSION" --no-git-tag-version --allow-same-version
           npm --prefix packages/playwright version "$VERSION" --no-git-tag-version --allow-same-version
           npm --prefix packages/appium     version "$VERSION" --no-git-tag-version --allow-same-version
+          npm --prefix packages/k6        version "$VERSION" --no-git-tag-version --allow-same-version
           npm --prefix packages/cli        version "$VERSION" --no-git-tag-version --allow-same-version
           npm --prefix packages/zosma-qa   version "$VERSION" --no-git-tag-version --allow-same-version
 
@@ -59,6 +60,12 @@ jobs:
       - name: Publish @zosmaai/zosma-qa-appium
         run: pnpm publish --access public --no-git-checks
         working-directory: packages/appium
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @zosmaai/zosma-qa-k6
+        run: pnpm publish --access public --no-git-checks
+        working-directory: packages/k6
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Adds version bump and npm publish step for @zosmaai/zosma-qa-k6 to the release workflow.
