### PR TITLE
feat(appium): complete Appium CLI commands and test helper implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ zosma-qa is a unified QA framework that gives you production-ready test infrastr
 | [`@zosmaai/zosma-qa-core`](packages/core/) | [![npm](https://img.shields.io/npm/v/@zosmaai/zosma-qa-core)](https://www.npmjs.com/package/@zosmaai/zosma-qa-core) | Shared types, config loader, plugin interface |
 | [`@zosmaai/zosma-qa-playwright`](packages/playwright/) | [![npm](https://img.shields.io/npm/v/@zosmaai/zosma-qa-playwright)](https://www.npmjs.com/package/@zosmaai/zosma-qa-playwright) | Playwright runner and base config |
 | [`@zosmaai/zosma-qa-cli`](packages/cli/) | [![npm](https://img.shields.io/npm/v/@zosmaai/zosma-qa-cli)](https://www.npmjs.com/package/@zosmaai/zosma-qa-cli) | Interactive CLI with prompts |
-| [`@zosmaai/zosma-qa-appium`](packages/appium/) | *Publishing with next release* | Appium mobile testing runner |
-| [`@zosmaai/zosma-qa-k6`](packages/k6/) | *Publishing with next release* | k6 load testing runner |
+| [`@zosmaai/zosma-qa-appium`](packages/appium/) | [![npm](https://img.shields.io/npm/v/@zosmaai/zosma-qa-appium)](https://www.npmjs.com/package/@zosmaai/zosma-qa-appium) | Appium mobile testing runner |
+| [`@zosmaai/zosma-qa-k6`](packages/k6/) | [![npm](https://img.shields.io/npm/v/@zosmaai/zosma-qa-k6)](https://www.npmjs.com/package/@zosmaai/zosma-qa-k6) | k6 load testing runner |
 
 ---
 

--- a/packages/appium/src/utils/test-helpers.ts
+++ b/packages/appium/src/utils/test-helpers.ts
@@ -4,157 +4,316 @@
  * Supports multiple locator strategies (testID, text, accessibility label, etc.)
  */
 
-// Placeholder types (will be replaced with actual WebdriverIO types)
-export interface Browser {
-  $: (selector: string) => Promise<unknown>;
-  $$: (selector: string) => Promise<unknown[]>;
-  [key: string]: unknown;
+import type { Browser } from 'webdriverio';
+
+// ─── Selector resolution ────────────────────────────────────────────────────
+
+type SelectorInput =
+  | string
+  | { testID?: string; text?: string; exact?: boolean; selector?: string };
+type InputSelectorInput =
+  | string
+  | { label?: string; placeholder?: string; testID?: string; selector?: string };
+
+function resolveSelector(sel: SelectorInput): string {
+  if (typeof sel === 'string') return sel;
+  if (sel.selector) return sel.selector;
+  if (sel.testID) return `~${sel.testID}`;
+  if (sel.text) {
+    const escaped = sel.text.replace(/"/g, '\\"');
+    return `//*[contains(@text,"${escaped}") or contains(@label,"${escaped}") or contains(@value,"${escaped}")]`;
+  }
+  throw new Error('Selector must include at least one of: testID, text, selector, or a string');
 }
+
+function resolveInputSelector(sel: InputSelectorInput): string {
+  if (typeof sel === 'string') return sel;
+  if (sel.selector) return sel.selector;
+  if (sel.testID) return `~${sel.testID}`;
+  if (sel.label) {
+    const escaped = sel.label.replace(/"/g, '\\"');
+    return `//*[contains(@text,"${escaped}") or contains(@label,"${escaped}")]`;
+  }
+  if (sel.placeholder) {
+    const escaped = sel.placeholder.replace(/"/g, '\\"');
+    return `//*[contains(@text,"${escaped}") or contains(@hint,"${escaped}")]`;
+  }
+  throw new Error(
+    'Input selector must include at least one of: testID, label, placeholder, selector, or a string',
+  );
+}
+
+function getAppId(driver: Browser): string {
+  const caps = driver.capabilities as Record<string, unknown>;
+  const appId =
+    caps['appium:bundleId'] || caps['appium:appPackage'] || caps.bundleId || caps.appPackage;
+  if (!appId) {
+    throw new Error(
+      'Cannot determine app ID from capabilities. Set appium:bundleId (iOS) or appium:appPackage (Android).',
+    );
+  }
+  return String(appId);
+}
+
+// ─── Interaction helpers ────────────────────────────────────────────────────
 
 /**
  * Tap/click a button by testID or text.
  */
 export async function tapButton(
-  _driver: Browser,
+  driver: Browser,
   selector: string | { testID?: string; text?: string; exact?: boolean; selector?: string },
 ): Promise<void> {
-  // Placeholder: would use driver.$ to locate button and click it
-  console.log(`Tapping button:`, selector);
+  const sel = resolveSelector(selector);
+  try {
+    const el = await driver.$(sel);
+    await el.waitForExist({ timeout: 5000 });
+    await el.click();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`tapButton failed for selector "${sel}": ${msg}`);
+  }
 }
 
 /**
  * Fill text input by label or testID.
  */
 export async function fillInput(
-  _driver: Browser,
+  driver: Browser,
   text: string,
-  selector: string | { label?: string; placeholder?: string; testID?: string },
+  selector: string | { label?: string; placeholder?: string; testID?: string; selector?: string },
 ): Promise<void> {
-  // Placeholder: would locate input and fill text
-  console.log(`Filling input:`, selector, `with text:`, text);
+  const sel = resolveInputSelector(selector);
+  try {
+    const el = await driver.$(sel);
+    await el.waitForExist({ timeout: 5000 });
+    await el.clearValue();
+    await el.setValue(text);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`fillInput failed for selector "${sel}" with text "${text}": ${msg}`);
+  }
 }
 
 /**
  * Assert text is visible on screen.
  */
 export async function expectText(
-  _driver: Browser,
+  driver: Browser,
   text: string,
-  _opts?: { timeout?: number; exact?: boolean; visible?: boolean },
+  opts?: { timeout?: number; exact?: boolean; visible?: boolean },
 ): Promise<void> {
-  // Placeholder
-  console.log(`Expecting text: ${text}`);
+  const timeout = opts?.timeout ?? 5000;
+  const escaped = text.replace(/"/g, '\\"');
+  const xpath = opts?.exact
+    ? `//*[@text="${escaped}" or @label="${escaped}" or @value="${escaped}"]`
+    : `//*[contains(@text,"${escaped}") or contains(@label,"${escaped}") or contains(@value,"${escaped}")]`;
+
+  try {
+    const el = await driver.$(xpath);
+    await el.waitForExist({ timeout });
+    if (opts?.visible) {
+      await el.waitForDisplayed({ timeout });
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`expectText failed — could not find text "${text}": ${msg}`);
+  }
 }
 
 /**
  * Assert element is visible.
  */
 export async function expectVisible(
-  _driver: Browser,
+  driver: Browser,
   selector: string | { testID: string },
-  _opts?: { timeout?: number },
+  opts?: { timeout?: number },
 ): Promise<void> {
-  // Placeholder
-  console.log(
-    `Expecting element visible: ${typeof selector === 'string' ? selector : selector.testID}`,
-  );
+  const sel = typeof selector === 'string' ? selector : `~${selector.testID}`;
+  const timeout = opts?.timeout ?? 5000;
+  try {
+    const el = await driver.$(sel);
+    await el.waitForDisplayed({ timeout });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`expectVisible failed for "${sel}": ${msg}`);
+  }
+}
+
+// ─── Gesture helpers ────────────────────────────────────────────────────────
+
+async function performSwipe(
+  driver: Browser,
+  direction: 'down' | 'up' | 'left' | 'right',
+  opts?: { distance?: number; duration?: number },
+): Promise<void> {
+  const { width, height } = await driver.getWindowSize();
+  const distance = opts?.distance ?? 0.6;
+  const duration = opts?.duration ?? 300;
+
+  const centerX = Math.round(width / 2);
+  const centerY = Math.round(height / 2);
+  const offsetX = Math.round((width * distance) / 2);
+  const offsetY = Math.round((height * distance) / 2);
+
+  let startX: number;
+  let startY: number;
+  let endX: number;
+  let endY: number;
+
+  switch (direction) {
+    case 'down':
+      startX = centerX;
+      startY = centerY - offsetY;
+      endX = centerX;
+      endY = centerY + offsetY;
+      break;
+    case 'up':
+      startX = centerX;
+      startY = centerY + offsetY;
+      endX = centerX;
+      endY = centerY - offsetY;
+      break;
+    case 'left':
+      startX = centerX + offsetX;
+      startY = centerY;
+      endX = centerX - offsetX;
+      endY = centerY;
+      break;
+    case 'right':
+      startX = centerX - offsetX;
+      startY = centerY;
+      endX = centerX + offsetX;
+      endY = centerY;
+      break;
+  }
+
+  await driver
+    .action('pointer', { parameters: { pointerType: 'touch' } })
+    .move({ x: startX, y: startY })
+    .down({ button: 0 })
+    .pause(duration)
+    .move({ x: endX, y: endY })
+    .up({ button: 0 })
+    .perform();
 }
 
 /**
  * Swipe down on screen.
  */
 export async function swipeDown(
-  _driver: Browser,
-  _opts?: { distance?: number; duration?: number },
+  driver: Browser,
+  opts?: { distance?: number; duration?: number },
 ): Promise<void> {
-  // Placeholder
-  console.log(`Swiping down`);
+  await performSwipe(driver, 'down', opts);
 }
 
 /**
  * Swipe up on screen.
  */
 export async function swipeUp(
-  _driver: Browser,
-  _opts?: { distance?: number; duration?: number },
+  driver: Browser,
+  opts?: { distance?: number; duration?: number },
 ): Promise<void> {
-  // Placeholder
-  console.log(`Swiping up`);
+  await performSwipe(driver, 'up', opts);
 }
 
 /**
  * Swipe left on screen.
  */
 export async function swipeLeft(
-  _driver: Browser,
-  _opts?: { distance?: number; duration?: number },
+  driver: Browser,
+  opts?: { distance?: number; duration?: number },
 ): Promise<void> {
-  // Placeholder
-  console.log(`Swiping left`);
+  await performSwipe(driver, 'left', opts);
 }
 
 /**
  * Swipe right on screen.
  */
 export async function swipeRight(
-  _driver: Browser,
-  _opts?: { distance?: number; duration?: number },
+  driver: Browser,
+  opts?: { distance?: number; duration?: number },
 ): Promise<void> {
-  // Placeholder
-  console.log(`Swiping right`);
+  await performSwipe(driver, 'right', opts);
 }
+
+// ─── Utility helpers ────────────────────────────────────────────────────────
 
 /**
  * Take a screenshot.
  */
-export async function takeScreenshot(_driver: Browser, name: string): Promise<string> {
-  // Placeholder
-  console.log(`Taking screenshot: ${name}`);
-  return `screenshot_${name}.png`;
+export async function takeScreenshot(driver: Browser, name: string): Promise<string> {
+  const filename = `screenshot_${name}_${Date.now()}.png`;
+  try {
+    await driver.saveScreenshot(filename);
+    return filename;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`takeScreenshot failed for "${name}": ${msg}`);
+  }
 }
 
 /**
  * Wait for element to appear.
  */
 export async function waitForElement(
-  _driver: Browser,
+  driver: Browser,
   selector: string,
-  _timeout?: number,
+  timeout?: number,
 ): Promise<void> {
-  // Placeholder
-  console.log(`Waiting for element: ${selector}`);
+  try {
+    const el = await driver.$(selector);
+    await el.waitForExist({ timeout: timeout ?? 10000 });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `waitForElement timed out after ${timeout ?? 10000}ms for selector "${selector}": ${msg}`,
+    );
+  }
 }
 
 /**
  * Go back (press back button or navigate back).
  */
-export async function goBack(_driver: Browser): Promise<void> {
-  // Placeholder
-  console.log(`Going back`);
+export async function goBack(driver: Browser): Promise<void> {
+  await driver.back();
 }
+
+// ─── App lifecycle helpers ──────────────────────────────────────────────────
 
 /**
  * Close the app.
  */
-export async function closeApp(_driver: Browser): Promise<void> {
-  // Placeholder
-  console.log(`Closing app`);
+export async function closeApp(driver: Browser): Promise<void> {
+  const appId = getAppId(driver);
+  try {
+    await driver.execute('mobile: terminateApp', { bundleId: appId, appId });
+  } catch {
+    // Fallback for older Appium / different driver implementations
+    await (driver as unknown as { closeApp: () => Promise<void> }).closeApp();
+  }
 }
 
 /**
  * Launch the app.
  */
-export async function launchApp(_driver: Browser): Promise<void> {
-  // Placeholder
-  console.log(`Launching app`);
+export async function launchApp(driver: Browser): Promise<void> {
+  const appId = getAppId(driver);
+  try {
+    await driver.execute('mobile: activateApp', { bundleId: appId, appId });
+  } catch {
+    // Fallback for older Appium / different driver implementations
+    await (driver as unknown as { launchApp: () => Promise<void> }).launchApp();
+  }
 }
 
 /**
- * Reset app to initial state.
+ * Reset app to initial state (terminate + relaunch).
  */
-export async function resetApp(_driver: Browser): Promise<void> {
-  // Placeholder
-  console.log(`Resetting app`);
+export async function resetApp(driver: Browser): Promise<void> {
+  await closeApp(driver);
+  await launchApp(driver);
 }
 
 /**

--- a/packages/appium/src/utils/test-helpers.ts
+++ b/packages/appium/src/utils/test-helpers.ts
@@ -15,12 +15,17 @@ type InputSelectorInput =
   | string
   | { label?: string; placeholder?: string; testID?: string; selector?: string };
 
+/** Escape a string for safe use inside XPath attribute selectors. */
+function escapeXPath(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 function resolveSelector(sel: SelectorInput): string {
   if (typeof sel === 'string') return sel;
   if (sel.selector) return sel.selector;
   if (sel.testID) return `~${sel.testID}`;
   if (sel.text) {
-    const escaped = sel.text.replace(/"/g, '\\"');
+    const escaped = escapeXPath(sel.text);
     return `//*[contains(@text,"${escaped}") or contains(@label,"${escaped}") or contains(@value,"${escaped}")]`;
   }
   throw new Error('Selector must include at least one of: testID, text, selector, or a string');
@@ -31,11 +36,11 @@ function resolveInputSelector(sel: InputSelectorInput): string {
   if (sel.selector) return sel.selector;
   if (sel.testID) return `~${sel.testID}`;
   if (sel.label) {
-    const escaped = sel.label.replace(/"/g, '\\"');
+    const escaped = escapeXPath(sel.label);
     return `//*[contains(@text,"${escaped}") or contains(@label,"${escaped}")]`;
   }
   if (sel.placeholder) {
-    const escaped = sel.placeholder.replace(/"/g, '\\"');
+    const escaped = escapeXPath(sel.placeholder);
     return `//*[contains(@text,"${escaped}") or contains(@hint,"${escaped}")]`;
   }
   throw new Error(
@@ -104,7 +109,7 @@ export async function expectText(
   opts?: { timeout?: number; exact?: boolean; visible?: boolean },
 ): Promise<void> {
   const timeout = opts?.timeout ?? 5000;
-  const escaped = text.replace(/"/g, '\\"');
+  const escaped = escapeXPath(text);
   const xpath = opts?.exact
     ? `//*[@text="${escaped}" or @label="${escaped}" or @value="${escaped}"]`
     : `//*[contains(@text,"${escaped}") or contains(@label,"${escaped}") or contains(@value,"${escaped}")]`;

--- a/packages/cli/src/commands/appium-agents.ts
+++ b/packages/cli/src/commands/appium-agents.ts
@@ -1,0 +1,286 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { select } from '@inquirer/prompts';
+import type { AgentLoop } from '@zosmaai/zosma-qa-core';
+import chalk from 'chalk';
+
+/**
+ * `zosma-qa appium agents init` — generate AI agent prompt files for mobile testing.
+ */
+export async function initAppiumAgents(loopOverride?: AgentLoop): Promise<void> {
+  let loop: AgentLoop;
+
+  if (loopOverride) {
+    loop = loopOverride;
+  } else {
+    console.log('');
+    console.log(
+      chalk.bold.cyan('  zosma-qa appium agents') + chalk.dim(' — mobile AI agent setup'),
+    );
+    console.log('');
+    console.log(
+      chalk.dim(
+        '  This generates agent definitions that let your AI tool act as a\n' +
+          '  mobile test planner, generator, healer, and analyzer.\n',
+      ),
+    );
+
+    loop = await select<AgentLoop>({
+      message: 'Which AI coding tool are you using?',
+      choices: [
+        {
+          name: 'OpenCode  (default)',
+          value: 'opencode',
+          description: 'opencode.ai — the AI coding agent',
+        },
+        {
+          name: 'Claude Code',
+          value: 'claude',
+          description: "Anthropic's Claude Code CLI (claude.ai/code)",
+        },
+        {
+          name: 'VS Code  (Copilot)',
+          value: 'vscode',
+          description: 'GitHub Copilot agent mode inside VS Code',
+        },
+      ],
+      default: 'opencode',
+    });
+  }
+
+  const cwd = process.cwd();
+  const promptsDir = getPromptsDir(cwd, loop);
+  fs.mkdirSync(promptsDir, { recursive: true });
+
+  const agents = [
+    { filename: 'appium-mobile-test-planner.md', content: PLANNER_PROMPT },
+    { filename: 'appium-mobile-test-generator.md', content: GENERATOR_PROMPT },
+    { filename: 'appium-mobile-test-healer.md', content: HEALER_PROMPT },
+    { filename: 'appium-mobile-test-analyzer.md', content: ANALYZER_PROMPT },
+  ];
+
+  for (const agent of agents) {
+    const filePath = path.join(promptsDir, agent.filename);
+    if (!fs.existsSync(filePath)) {
+      fs.writeFileSync(filePath, agent.content, 'utf8');
+      console.log(chalk.green(`  Created  ${path.relative(cwd, filePath)}`));
+    } else {
+      console.log(chalk.dim(`  Skipped  ${path.relative(cwd, filePath)}  (already exists)`));
+    }
+  }
+
+  console.log('');
+  console.log(chalk.bold.green('  Agent definitions generated!'));
+  console.log('');
+  console.log(chalk.dim('  Four agents are now available:\n'));
+  console.log(`  ${chalk.bold('📱 planner')}    explores your app and writes a mobile test plan`);
+  console.log(`  ${chalk.bold('📱 generator')}  turns the plan into Appium test scripts`);
+  console.log(`  ${chalk.bold('📱 healer')}     runs failing mobile tests and repairs them`);
+  console.log(`  ${chalk.bold('📱 analyzer')}   runs tests and analyzes mobile test results`);
+  console.log('');
+  console.log(
+    chalk.dim(
+      '  Prompt your AI tool:\n' +
+        `    "${chalk.white('Use the appium-mobile-test-planner agent to plan tests for my app')}"\n`,
+    ),
+  );
+}
+
+function getPromptsDir(cwd: string, loop: AgentLoop): string {
+  switch (loop) {
+    case 'opencode':
+      return path.join(cwd, '.opencode', 'prompts');
+    case 'claude':
+      return path.join(cwd, '.github', 'agents');
+    case 'vscode':
+      return path.join(cwd, '.github', 'agents');
+    default:
+      return path.join(cwd, '.github', 'agents');
+  }
+}
+
+const PLANNER_PROMPT = `---
+name: appium-mobile-test-planner
+description: Explores the mobile app and creates a mobile test plan
+---
+
+# Appium Mobile Test Planner
+
+You are an expert mobile QA engineer. Your job is to explore the mobile app and create a comprehensive test plan.
+
+## Workflow
+
+1. **Discover app structure** — Look for:
+   - React Native navigation config (\`navigation/\`, \`App.tsx\`, route definitions)
+   - Native iOS screens (\`*.storyboard\`, \`*.xib\`, SwiftUI views)
+   - Native Android activities/fragments (\`AndroidManifest.xml\`, layouts)
+   - Flutter widget tree (\`lib/\`, route definitions)
+   - Accessibility labels and testID props in source code
+
+2. **Map screens and flows** — For each screen, note:
+   - Screen name and navigation path
+   - Interactive elements (buttons, inputs, toggles, pickers)
+   - testIDs or accessibility labels available
+   - Data dependencies (API calls, local storage)
+   - Platform differences (iOS vs Android behavior)
+
+3. **Design test scenarios** — Prioritize:
+   - **Critical paths**: login, signup, checkout, core CRUD flows
+   - **Navigation**: tab switching, deep links, back navigation, gestures
+   - **Forms**: input validation, keyboard interactions, error states
+   - **Gestures**: swipe, scroll, pull-to-refresh, pinch-to-zoom
+   - **Permissions**: camera, location, notifications, contacts
+   - **Edge cases**: no network, low memory, app backgrounding, orientation changes
+
+4. **Write the plan** — Save to \`specs/\`:
+   - \`specs/appium-test-plan.md\`
+   - Include: screen inventory, test scenarios per screen, element selectors, platform notes
+   - Note prerequisites (test accounts, backend state, device requirements)
+
+## Rules
+- Always check for existing testIDs in source code before proposing selector strategies
+- Consider both iOS and Android — note platform-specific behaviors
+- Prioritize tests by user impact and failure risk
+- Save plans to the existing \`specs/\` directory
+`;
+
+const GENERATOR_PROMPT = `---
+name: appium-mobile-test-generator
+description: Generates Appium test scripts from a mobile test plan
+---
+
+# Appium Mobile Test Generator
+
+You are an expert Appium test writer. Your job is to read test plans from \`specs/\` and generate working Appium test files.
+
+## Workflow
+
+1. **Read the test plan** from \`specs/appium-test-plan.md\` (or other plan files in \`specs/\`)
+
+2. **Generate test files** in the \`tests/\` directory:
+   - Name files descriptively: \`login.appium.ts\`, \`navigation.appium.ts\`, etc.
+   - Use the zosma-qa test builder API:
+     \`\`\`typescript
+     import { test, tapButton, fillInput, expectText, expectVisible, swipeDown, wait } from '@zosmaai/zosma-qa-appium';
+     \`\`\`
+   - Structure with \`test.describe()\` for grouping and \`test()\` for individual tests
+   - Use \`test.beforeEach()\` and \`test.afterEach()\` for setup/teardown
+
+3. **Use the helper functions**:
+   - \`tapButton(driver, { testID: '...' })\` — tap buttons and links
+   - \`fillInput(driver, 'text', { testID: '...' })\` — fill text inputs
+   - \`expectText(driver, 'text', { visible: true })\` — assert text on screen
+   - \`expectVisible(driver, { testID: '...' })\` — assert element visibility
+   - \`swipeDown(driver)\` / \`swipeUp(driver)\` — scroll content
+   - \`waitForElement(driver, '~elementId', 5000)\` — wait for elements
+   - \`goBack(driver)\` — navigate back
+   - \`takeScreenshot(driver, 'name')\` — capture screenshots
+
+4. **Validate with a smoke run**:
+   \`\`\`bash
+   npx zosma-qa appium run --grep "should"
+   \`\`\`
+   - If the smoke run fails, diagnose and fix the test
+
+## Rules
+- Always use testID selectors when available (most reliable across platforms)
+- Add appropriate waits — mobile apps have animations and network delays
+- Handle platform differences with conditional logic when needed
+- Keep tests independent — each test should work in isolation
+- Always smoke-test generated files before marking them as done
+`;
+
+const HEALER_PROMPT = `---
+name: appium-mobile-test-healer
+description: Runs failing Appium tests and fixes them
+---
+
+# Appium Mobile Test Healer
+
+You are an expert at diagnosing and fixing mobile test failures. Your job is to run failing Appium tests, diagnose issues, and fix them.
+
+## Workflow
+
+1. **Run the tests**:
+   \`\`\`bash
+   npx zosma-qa appium run
+   \`\`\`
+
+2. **Diagnose failures** — Common mobile test issues:
+   - **Element not found** — wrong selector, element not loaded yet, different element hierarchy on iOS vs Android
+   - **Stale element** — element re-rendered after navigation or state change
+   - **Timeout** — animation delays, slow network, app startup time
+   - **Permission dialogs** — system alerts blocking interaction (camera, location, notifications)
+   - **Keyboard overlay** — keyboard covering elements, need to scroll or dismiss
+   - **Orientation changes** — layout shift breaking selectors
+   - **App crash** — check Appium server logs for stack traces
+   - **Session creation failed** — Appium server not running, wrong capabilities, missing drivers
+
+3. **Fix the tests**:
+   - Update selectors (prefer testID > accessibility label > XPath)
+   - Add \`waitForElement()\` before interactions
+   - Add \`wait()\` after navigation or animations
+   - Handle system dialogs with Appium's auto-accept capabilities
+   - Dismiss keyboard before tapping elements below it
+   - Increase timeouts for slow operations
+
+4. **Re-run and verify**:
+   \`\`\`bash
+   npx zosma-qa appium run
+   \`\`\`
+
+5. **Report unfixable issues** — If the issue is in the app itself (crash, broken feature), document it clearly rather than working around it in tests
+
+## Rules
+- Never remove assertions to make tests pass — fix the root cause
+- Always re-run after fixing to verify the fix works
+- If Appium server is not running, start it: \`appium\`
+- Prefer adding testIDs in the app source over fragile XPath selectors
+- Check both iOS and Android if tests fail on only one platform
+`;
+
+const ANALYZER_PROMPT = `---
+name: appium-mobile-test-analyzer
+description: Runs Appium tests and analyzes mobile test results
+---
+
+# Appium Mobile Test Analyzer
+
+You are an expert mobile QA analyst. Your job is to run Appium tests, read the results, and provide actionable analysis.
+
+## Workflow
+
+1. **Run the tests**:
+   \`\`\`bash
+   npx zosma-qa appium run
+   \`\`\`
+
+2. **Read results** from \`test-results/\` directory and console output
+
+3. **Analyze results**:
+   - **Pass/fail rate**: Overall health of the test suite
+   - **Duration patterns**: Slow tests may indicate animation issues, network delays, or inefficient selectors
+   - **Flaky tests**: Tests that pass intermittently suggest timing issues or race conditions
+   - **Platform comparison**: If running on both iOS and Android, compare results
+   - **Screenshot analysis**: Review failure screenshots for visual issues
+
+4. **Identify improvement areas**:
+   - Tests without proper waits (timing-dependent failures)
+   - Missing testIDs in the app (fragile XPath selectors)
+   - Tests that could run in parallel (independent flows)
+   - Missing test coverage (screens or flows without tests)
+   - Redundant tests (overlapping assertions)
+
+5. **Write analysis** to \`specs/\` or stdout:
+   - Summary of test health
+   - Per-flow breakdown (login, navigation, forms, etc.)
+   - Platform-specific issues
+   - Recommendations for improving reliability and speed
+
+## Rules
+- Always run the tests first — don't analyze stale results without mentioning it
+- Be specific about which tests need attention and why
+- Provide actionable recommendations, not just observations
+- If results look good, say so — not every analysis needs to find problems
+- Suggest testID additions in app source code when XPath selectors are fragile
+`;

--- a/packages/cli/src/commands/appium.ts
+++ b/packages/cli/src/commands/appium.ts
@@ -1,0 +1,195 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { AppiumRunner } from '@zosmaai/zosma-qa-appium';
+import { loadConfig } from '@zosmaai/zosma-qa-core';
+import chalk from 'chalk';
+
+export interface AppiumRunOptions {
+  platform?: string;
+  device?: string;
+  app?: string;
+  port?: string;
+  verbose?: boolean;
+  grep?: string;
+}
+
+/**
+ * `zosma-qa appium run` — execute Appium mobile tests.
+ */
+export async function runAppium(options: AppiumRunOptions = {}): Promise<void> {
+  console.log('');
+  console.log(chalk.bold.cyan('  zosma-qa') + chalk.dim('  running Appium mobile tests'));
+  console.log('');
+
+  const cwd = process.cwd();
+  const config = await loadConfig(cwd);
+
+  const runner = new AppiumRunner({
+    testDir: config.testDir,
+    baseURL: config.baseURL,
+    browsers: [],
+    reporters: [],
+    ci: false,
+    extraArgs: buildExtraArgs(options),
+  });
+
+  const results = await runner.execute();
+
+  // Print summary
+  console.log('');
+  const passed = results.filter((r) => r.status === 'passed').length;
+  const failed = results.filter((r) => r.status === 'failed').length;
+  const skipped = results.filter((r) => r.status === 'skipped').length;
+
+  if (failed > 0) {
+    console.log(
+      chalk.bold.red(`  ${failed} failed`) + chalk.dim(`, ${passed} passed, ${skipped} skipped`),
+    );
+    for (const r of results.filter((r) => r.status === 'failed')) {
+      console.log(chalk.red(`    ✗ ${r.name}`) + (r.error ? chalk.dim(` — ${r.error}`) : ''));
+    }
+  } else if (skipped > 0 && passed === 0) {
+    console.log(chalk.yellow(`  ${skipped} skipped`));
+    for (const r of results.filter((r) => r.status === 'skipped')) {
+      console.log(chalk.dim(`    - ${r.name}`) + (r.error ? chalk.dim(` — ${r.error}`) : ''));
+    }
+  } else {
+    console.log(chalk.bold.green(`  ${passed} passed`));
+  }
+  console.log('');
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+function buildExtraArgs(options: AppiumRunOptions): string[] {
+  const args: string[] = [];
+  if (options.platform) args.push('--platform', options.platform);
+  if (options.device) args.push('--device', options.device);
+  if (options.app) args.push('--app', options.app);
+  if (options.port) args.push('--port', options.port);
+  if (options.verbose) args.push('--verbose');
+  if (options.grep) args.push('--grep', options.grep);
+  return args;
+}
+
+/**
+ * `zosma-qa appium init` — scaffold Appium test structure.
+ */
+export async function initAppium(): Promise<void> {
+  const cwd = process.cwd();
+
+  console.log('');
+  console.log(
+    chalk.bold.cyan('  zosma-qa appium init') + chalk.dim(' — scaffold Appium mobile tests'),
+  );
+  console.log('');
+
+  // Create tests/ directory
+  const testsDir = path.join(cwd, 'tests');
+  if (!fs.existsSync(testsDir)) {
+    fs.mkdirSync(testsDir, { recursive: true });
+  }
+
+  // Create example test file
+  const examplePath = path.join(testsDir, 'login.appium.ts');
+  if (!fs.existsSync(examplePath)) {
+    fs.writeFileSync(examplePath, EXAMPLE_TEST, 'utf8');
+    console.log(chalk.green(`  Created  tests/login.appium.ts`));
+  } else {
+    console.log(chalk.dim(`  Skipped  tests/login.appium.ts  (already exists)`));
+  }
+
+  // Create appium.config.ts
+  const configPath = path.join(cwd, 'appium.config.ts');
+  if (!fs.existsSync(configPath)) {
+    fs.writeFileSync(configPath, APPIUM_CONFIG_TEMPLATE, 'utf8');
+    console.log(chalk.green(`  Created  appium.config.ts`));
+  } else {
+    console.log(chalk.dim(`  Skipped  appium.config.ts  (already exists)`));
+  }
+
+  // Create test-results/ directory
+  const resultsDir = path.join(cwd, 'test-results');
+  if (!fs.existsSync(resultsDir)) {
+    fs.mkdirSync(resultsDir, { recursive: true });
+    fs.writeFileSync(path.join(resultsDir, '.gitkeep'), '', 'utf8');
+  }
+
+  console.log('');
+  console.log(`${chalk.bold.green('  Ready!')}  Next steps:\n`);
+  console.log(chalk.dim('  1. Install Appium (if not installed):'));
+  console.log(chalk.cyan('     npm install -g appium'));
+  console.log('');
+  console.log(chalk.dim('  2. Install platform drivers:'));
+  console.log(chalk.cyan('     appium driver install xcuitest     # iOS'));
+  console.log(chalk.cyan('     appium driver install uiautomator2 # Android'));
+  console.log('');
+  console.log(chalk.dim('  3. Edit appium.config.ts with your app path and platform'));
+  console.log('');
+  console.log(chalk.dim('  4. Run your mobile tests:'));
+  console.log(chalk.cyan('     npx zosma-qa appium run'));
+  console.log('');
+}
+
+const EXAMPLE_TEST = `import {
+  test,
+  tapButton,
+  fillInput,
+  expectText,
+  expectVisible,
+  wait,
+} from '@zosmaai/zosma-qa-appium';
+
+test.describe('Login Flow', () => {
+  test('should log in with valid credentials', async ({ driver }) => {
+    // Wait for the app to load
+    await expectVisible(driver, { testID: 'login-screen' }, { timeout: 10000 });
+
+    // Fill in credentials
+    await fillInput(driver, 'user@example.com', { testID: 'email-input' });
+    await fillInput(driver, 'password123', { testID: 'password-input' });
+
+    // Tap the login button
+    await tapButton(driver, { testID: 'login-button' });
+
+    // Verify we reach the home screen
+    await expectText(driver, 'Welcome', { timeout: 5000, visible: true });
+  });
+
+  test('should show error for invalid credentials', async ({ driver }) => {
+    await fillInput(driver, 'invalid@example.com', { testID: 'email-input' });
+    await fillInput(driver, 'wrong', { testID: 'password-input' });
+    await tapButton(driver, { testID: 'login-button' });
+
+    await wait(1000);
+    await expectText(driver, 'Invalid credentials');
+  });
+});
+`;
+
+const APPIUM_CONFIG_TEMPLATE = `import { defineConfig } from '@zosmaai/zosma-qa-core';
+
+export default defineConfig({
+  plugins: ['appium'],
+  testDir: './tests',
+
+  // ─── Platform configuration ──────────────────────────────────
+  // platformName: 'iOS',         // 'iOS' | 'Android' | 'ReactNative'
+  // appPath: './path/to/your.app',
+  // appId: 'com.example.myapp',
+
+  // ─── Device configuration ────────────────────────────────────
+  // deviceName: 'iPhone 15 Pro',
+  // platformVersion: '17.0',
+
+  // ─── Appium server ───────────────────────────────────────────
+  // appiumPort: 4723,
+  // appiumHost: 'localhost',
+
+  // ─── Timeouts ────────────────────────────────────────────────
+  // launchTimeout: 60000,
+  // commandTimeout: 30000,
+});
+`;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,7 @@
 import { Command } from 'commander';
 import { initAgents } from './commands/agents';
+import { initAppium, runAppium } from './commands/appium';
+import { initAppiumAgents } from './commands/appium-agents';
 import { runInit } from './commands/init';
 import { initK6, runK6 } from './commands/k6';
 import { initK6Agents } from './commands/k6-agents';
@@ -81,6 +83,42 @@ k6AgentsCmd
   .option('--loop <loop>', 'AI loop to use: opencode | claude | vscode')
   .action(async (options) => {
     await initK6Agents(options.loop);
+  });
+
+// ─── appium ──────────────────────────────────────────────────────────────────
+
+const appiumCmd = program.command('appium').description('Manage Appium mobile tests');
+
+appiumCmd
+  .command('run')
+  .description('Run Appium mobile tests')
+  .option('--platform <platform>', 'Target platform: iOS | Android | ReactNative')
+  .option('--device <device>', 'Device name or ID')
+  .option('--app <path>', 'Path to app binary (APK/IPA)')
+  .option('--port <n>', 'Appium server port')
+  .option('--verbose', 'Enable verbose logging')
+  .option('-g, --grep <pattern>', 'Only run tests matching this pattern')
+  .action(async (options) => {
+    await runAppium(options);
+  });
+
+appiumCmd
+  .command('init')
+  .description('Scaffold Appium test structure with example test and config')
+  .action(async () => {
+    await initAppium();
+  });
+
+const appiumAgentsCmd = appiumCmd
+  .command('agents')
+  .description('Manage Appium AI agent definitions');
+
+appiumAgentsCmd
+  .command('init')
+  .description('Generate Appium AI agent definitions for your AI coding tool')
+  .option('--loop <loop>', 'AI loop to use: opencode | claude | vscode')
+  .action(async (options) => {
+    await initAppiumAgents(options.loop);
   });
 
 // ─── report ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Completes the Appium mobile testing package to match the Playwright and k6 CLI experience. Implements all 14 stub test helper functions with real WebdriverIO v9 API calls and adds appium init, appium run, and appium agents init CLI commands. 

## Related issue

Closes the Appium "Available" status gap — the package had infrastructure (runner, server, device manager, session manager) but was missing the user-facing CLI layer and functional test helpers needed for publishing. 

## Checklist

- [ ] `pnpm build` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] Implement 14 test helpers with real WebdriverIO v9 calls (tap, fill, swipe gestures, screenshots, app lifecycle)
- [ ] Add npx zosma-qa appium init — scaffolds config, example test, results dir
- [ ] Add npx zosma-qa appium run — executes tests with pass/fail summary
- [ ] Add npx zosma-qa appium agents init — generates 4 AI agent prompts (planner, generator, healer, analyzer)
- [ ] Register all Appium commands in CLI entry point
- [ ] Update README — replace "Publishing with next release" with npm version badges
